### PR TITLE
MJ Divider improvements 

### DIFF
--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -10,7 +10,7 @@ import _ from 'lodash'
   attributes: {
     'border-color': '#000000',
     'border-style': 'solid',
-    'border-width': '4px 0 0',
+    'border-width': '4px',
     'horizontal-spacing': '10px',
     'padding-bottom': '10px',
     'padding-left': '25px',
@@ -23,8 +23,7 @@ import _ from 'lodash'
 class Divider extends Component {
 
   static baseStyles = {
-    div: {
-      height: '0',
+    p: {
       fontSize: '1px'
     }
   };
@@ -33,14 +32,13 @@ class Divider extends Component {
     const { mjAttribute } = this.props
 
     return _.merge({}, this.constructor.baseStyles, {
-      div: {
-        borderColor: mjAttribute('border-color'),
-        borderStyle: mjAttribute('border-style'),
-        borderWidth: mjAttribute('border-width'),
-        marginBottom: mjAttribute('vertical-spacing'),
-        marginLeft: mjAttribute('horizontal-spacing'),
-        marginRight: mjAttribute('horizontal-spacing'),
-        marginTop: mjAttribute('vertical-spacing')
+      p: {
+        borderTop: `${mjAttribute('border-width')} ${mjAttribute('border-style')} ${mjAttribute('border-color')}`,
+        paddingBottom: mjAttribute('vertical-spacing'),
+        paddingLeft: mjAttribute('horizontal-spacing'),
+        paddingRight: mjAttribute('horizontal-spacing'),
+        paddingTop: mjAttribute('vertical-spacing'),
+        width: "100%"
       }
     })
   }
@@ -48,7 +46,7 @@ class Divider extends Component {
   render() {
     this.styles = this.getStyles()
 
-    return <div style={this.styles.div} />
+    return <p style={this.styles.p} />
   }
 
 }

--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -34,10 +34,6 @@ class Divider extends Component {
     return _.merge({}, this.constructor.baseStyles, {
       p: {
         borderTop: `${mjAttribute('border-width')} ${mjAttribute('border-style')} ${mjAttribute('border-color')}`,
-        paddingBottom: mjAttribute('vertical-spacing'),
-        paddingLeft: mjAttribute('horizontal-spacing'),
-        paddingRight: mjAttribute('horizontal-spacing'),
-        paddingTop: mjAttribute('vertical-spacing'),
         width: "100%"
       }
     })
@@ -46,7 +42,7 @@ class Divider extends Component {
   render() {
     this.styles = this.getStyles()
 
-    return <p style={this.styles.p} />
+    return <p className="outlook-divider-fix" style={this.styles.p} />
   }
 
 }

--- a/src/mjml2html.js
+++ b/src/mjml2html.js
@@ -109,8 +109,6 @@ const internals = {
         </v:rect>
         <![endif]-->
       `)
-
-
     })
 
     $(".mj-body-outlook-open").each(function() {
@@ -150,6 +148,13 @@ const internals = {
       $(this).replaceWith(`<!--[if mso]>
       </td></tr></table>
       <![endif]-->`)
+    })
+
+    $(".outlook-divider-fix").each(function() {
+      const $insertNode = $('<table></table>').css($(this).css())
+
+      $(this).removeClass("outlook-divider-fix")
+             .after(`<!--[if mso]>${$insertNode}<![endif]-->`)
     })
   },
 


### PR DESCRIPTION
- Should now correctly render in all clients
- Remove `horizontal-spacing` & `vertical-spacing`, replaced by standard padding-left/right/top/bottom