### PR TITLE
Correct the generation of component with an ending tag + refactoring on cli specs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/**
+test/assets/**

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.15.0",
+    "fs-promise": "^0.4.1",
     "mocha": "^2.3.4"
   },
   "dependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -127,7 +127,7 @@ class ${name} extends Component {
   }
 }
 
-registerElement('${lowerName}', ${name}${ending ? ', true' : ''})
+registerElement('${lowerName}', ${name}${ending ? ', { endingTag: true }' : ''})
 export default ${name}
 `
 }

--- a/test/assets/generatedComponent.js
+++ b/test/assets/generatedComponent.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react'
+import _ from 'lodash'
+import {
+  MJMLColumnElement,
+  elements,
+  registerElement,
+} from 'mjml'
+
+/*
+ * Wrap your dependencies here.
+ */
+const {
+  text: MjText,
+} = elements;
+
+const NAME = 'mock'
+
+@MJMLColumnElement({
+  tagName: 'mj-mock',
+  content: ' ',
+
+  /*
+   * These are your default css attributes
+   */
+  attributes: {
+    'color': '#424242',
+    'font-family': 'Helvetica',
+    'margin-top': '10px'
+  }
+})
+class Mock extends Component {
+
+  /*
+   * Build your styling here
+   */
+  getStyles() {
+    const { mjAttribute, color } = this.props
+
+    return _.merge({}, this.constructor.baseStyles, {
+      text: {
+        /*
+         * Get the color attribute
+         * Example: <mj-mock color="blue">content</mj-mock>
+         */
+        color: mjAttribute('color')
+      }
+    })
+  }
+
+  render() {
+
+    const css = this.getStyles(),
+      content = 'Hello World!'
+
+    return (
+      <MjText style={ css }>
+        { content }
+      </MjText>
+    )
+  }
+}
+
+registerElement('mock', Mock)
+export default Mock

--- a/test/assets/generatedComponentEndingTag.js
+++ b/test/assets/generatedComponentEndingTag.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react'
+import _ from 'lodash'
+import {
+  MJMLColumnElement,
+  elements,
+  registerElement,
+} from 'mjml'
+
+/*
+ * Wrap your dependencies here.
+ */
+const {
+  text: MjText,
+} = elements;
+
+const NAME = 'mock'
+
+@MJMLColumnElement({
+  tagName: 'mj-mock',
+  content: ' ',
+
+  /*
+   * These are your default css attributes
+   */
+  attributes: {
+    'color': '#424242',
+    'font-family': 'Helvetica',
+    'margin-top': '10px'
+  }
+})
+class Mock extends Component {
+
+  /*
+   * Build your styling here
+   */
+  getStyles() {
+    const { mjAttribute, color } = this.props
+
+    return _.merge({}, this.constructor.baseStyles, {
+      text: {
+        /*
+         * Get the color attribute
+         * Example: <mj-mock color="blue">content</mj-mock>
+         */
+        color: mjAttribute('color')
+      }
+    })
+  }
+
+  render() {
+
+    const css = this.getStyles(),
+      content = 'Hello World!'
+
+    return (
+      <MjText style={ css }>
+        { content }
+      </MjText>
+    )
+  }
+}
+
+registerElement('mock', Mock, { endingTag: true })
+export default Mock


### PR DESCRIPTION
The cli was generating (--init-component) an error for an ending tag component. The method `registerElement` of [MJMLElementsCollection.js](https://github.com/mjmlio/mjml/blob/master/src/MJMLElementsCollection.js) expects an object instead of a boolean for the third parameter:

```javascript
if (options.endingTag) {
  endingTags.push(`mj-${tagName}`)
}
```

I used this occasion to refactor the cli specs, tell me what you think :)