### PR TITLE
Stream support for cli

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -54,11 +54,11 @@ const readStdin = promisify(stdinToBuffer)
 /*
  * Render an input promise
  */
-const render = (bufferPromise, { min, output }) => {
+const render = (bufferPromise, { min, output, stdout }) => {
   bufferPromise
     .then(mjml    => engine(mjml.toString()))
     .then(html    => min ? minify(html) : html)
-    .then(result  => write(output, result))
+    .then(result  => stdout ? process.stdout.write(result) : write(output, result))
     .catch(error)
 }
 

--- a/src/mjml.js
+++ b/src/mjml.js
@@ -16,8 +16,10 @@ const main = () => {
 
   binary
     .option('-r, --render <file>', 'Compiles an MJML file')
+    .option('-i, --render-stream', 'Compiles an MJML file from input stream')
     .option('-w, --watch <file>', 'Watch and render an MJML file')
     .option('-o, --output <file>', 'Redirect the HTML to a file', 'a.html')
+    .option('--stdout', 'Redirect the HTML to a stdout')
     .option('-m, --min', 'Minify the final output file', 'false')
     .option('-e, --ending', 'Specifies that the newly created component is an ending tag')
     .option('--register <name>', 'Initialize a self-registering MJML component (deprecated)')
@@ -26,11 +28,12 @@ const main = () => {
   binary.parse(process.argv)
 
   switch (true) {
-    case (!!binary.watch)     : return mjmlCLI.watch(binary.watch, binary)
-    case (!!binary.render)    : return mjmlCLI.render(binary.render, binary)
+    case (!!binary.watch)           : return mjmlCLI.watch(binary.watch, binary)
+    case (!!binary.render)          : return mjmlCLI.renderFile(binary.render, binary)
+    case (!!binary.renderStream)    : return mjmlCLI.renderStream(binary)
     case (!!binary.register)  : console.error("--register option is deprecated, please now use --init-component"); return process.exit(1)
-    case (!!binary.initComponent)  : return mjmlCLI.initComponent(binary.initComponent, binary.ending, false)
-    default                   : return console.log(mjmlCLI.version())
+    case (!!binary.initComponent)   : return mjmlCLI.initComponent(binary.initComponent, binary.ending, false)
+    default                         : return console.log(mjmlCLI.version())
   }
 }
 

--- a/src/mjml.js
+++ b/src/mjml.js
@@ -16,10 +16,10 @@ const main = () => {
 
   binary
     .option('-r, --render <file>', 'Compiles an MJML file')
-    .option('-i, --render-stream', 'Compiles an MJML file from input stream')
+    .option('-i, --stdin', 'Compiles an MJML file from input stream')
     .option('-w, --watch <file>', 'Watch and render an MJML file')
     .option('-o, --output <file>', 'Redirect the HTML to a file', 'a.html')
-    .option('--stdout', 'Redirect the HTML to a stdout')
+    .option('-s, --stdout', 'Redirect the HTML to stdout')
     .option('-m, --min', 'Minify the final output file', 'false')
     .option('-e, --ending', 'Specifies that the newly created component is an ending tag')
     .option('--register <name>', 'Initialize a self-registering MJML component (deprecated)')
@@ -30,8 +30,8 @@ const main = () => {
   switch (true) {
     case (!!binary.watch)           : return mjmlCLI.watch(binary.watch, binary)
     case (!!binary.render)          : return mjmlCLI.renderFile(binary.render, binary)
-    case (!!binary.renderStream)    : return mjmlCLI.renderStream(binary)
-    case (!!binary.register)  : console.error("--register option is deprecated, please now use --init-component"); return process.exit(1)
+    case (!!binary.stdin)           : return mjmlCLI.renderStream(binary)
+    case (!!binary.register)        : console.error("--register option is deprecated, please now use --init-component"); return process.exit(1)
     case (!!binary.initComponent)   : return mjmlCLI.initComponent(binary.initComponent, binary.ending, false)
     default                         : return console.log(mjmlCLI.version())
   }


### PR DESCRIPTION
Added stream support for cli.

Functions as before but with 2 extra option flags:
- `-s, --stdout` to output to stdout instead of file
- `-i, --stdin` to get the mjml source from input stream