### PR TITLE
Remove 'color' props from childDefaultProps

### DIFF
--- a/src/components/decorators/MJMLElement.js
+++ b/src/components/decorators/MJMLElement.js
@@ -98,7 +98,6 @@ function createComponent(ComposedComponent, defaultAttributes) {
       return {
         id,
         key: id,
-        color: this.mjAttribute('color'),
         parentWidth: this.getWidth(),
         verticalAlign: this.mjAttribute('vertical-align'),
         sibling: this.siblingsCount()


### PR DESCRIPTION
Remove color props from childDefaultProps 'cause if a parent component need to "renderChildren", default child color attribute is not available