### PR TITLE
Fix and remove mj-image default css width

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -29,8 +29,7 @@ class Image extends Component {
       border: 'none',
       display: 'block',
       outline: 'none',
-      textDecoration: 'none',
-      width: '100%'
+      textDecoration: 'none'
     }
   }
 


### PR DESCRIPTION
There is no reason to add 100% default css width