### PR TITLE
Fixed ignored alignment for social icons

### DIFF
--- a/src/components/Social.js
+++ b/src/components/Social.js
@@ -111,6 +111,9 @@ class Social extends Component {
     const { mjAttribute } = this.props
 
     return _.merge({}, this.constructor.baseStyles, {
+      div: {
+        textAlign: mjAttribute('align')
+      },
       a: {
         color: mjAttribute('color'),
         fontFamily: mjAttribute('font-family'),


### PR DESCRIPTION
The align attribute on mj-social is being ignored right now.