### PR TITLE
Better productivity with SpeedyTag

### DIFF
--- a/src/documentParser.js
+++ b/src/documentParser.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { endingTags } from './MJMLElementsCollection'
 import { ParseError, EmptyMJMLError, NullElementError } from './Error'
 import dom from './helpers/dom'
+import { speedyTagToMJM, presenceOfSpeedyTag } from './helpers/speedyTag'
 
 /**
  * Avoid htmlparser to parse ending tags
@@ -47,7 +48,7 @@ const mjmlElementParser = elem => {
  */
 const documentParser = content => {
   let body
-
+  if (presenceOfSpeedyTag(content)) { content = speedyTagToMJM(content) }
   try {
     const $ = dom.parseXML(safeEndingTags(content))
     body = $('mj-body')

--- a/src/helpers/speedyTag.js
+++ b/src/helpers/speedyTag.js
@@ -1,0 +1,43 @@
+export const regexForSpeedyTag = new RegExp(`( *)= *([a-z-]+) *([^>]*)`)
+export const orphansTags =  ['img', 'br', 'hr', 'input', 'area', 'link',
+'mj-invoice-item', 'mj-social', 'mj-image', 'mj-divider', 'mj-location']
+
+export const speedyTagToMJM = content => {
+  const lines = content.split('\n')
+  const stack = []
+  let mjmContent = ''
+  lines.forEach(line => {
+    const match = line.match(regexForSpeedyTag)
+    if (match) {
+      if (match[3]) { match[3] = ' ' + match[3] }
+      const nb_space = match[1].length
+      if (orphansTags.indexOf(match[2]) < 0) {
+        mjmContent += match[1] + '<' + match[2] + match[3] + '/>' + '\n'
+      } else {
+        if (stack.length > 0 && nb_space <= stack[stack.length - 1][0]) {
+          while (stack.length > 0 && nb_space <= stack[stack.length - 1][0]) {
+            mjmContent += stack[stack.length - 1][1] + '</' + stack[stack.length - 1][2] + '>' + '\n'
+            stack.pop()
+          }
+        }
+        stack.push([nb_space, match[1], match[2], + match[3]])
+        mjmContent += match[1] + '<' + match[2] + match[3] + '>' + '\n'
+      }
+    } else if (line != '' && line != ' ') { mjmContent += line + '\n' }
+  })
+  while (stack.length > 0) {
+    mjmContent += stack[stack.length - 1][1] + '</' + stack[stack.length - 1][2] + '>' + '\n'
+    stack.pop()
+  }
+  return mjmContent;
+}
+
+export const presenceOfSpeedyTag = content => {
+  const lines = content.split('\n')
+  let ret = false
+  lines.forEach(line => {
+    const match = line.match(regexForSpeedyTag)
+    if (match) { ret = true }
+  })
+  return ret
+}

--- a/test/assets/components.mjml.ft
+++ b/test/assets/components.mjml.ft
@@ -1,0 +1,42 @@
+= mj-body
+  = mj-section
+    = mj-column
+      = mj-table
+        = tr style="border-bottom:1px solid #ecedee;text-align:left;padding:15px 0;"
+          = th style="padding: 0 15px 0 0;"
+            Year
+          = th style="padding: 0 15px;"
+            Language
+          = th style="padding: 0 0 0 15px;"
+            Inspired from
+        = tr
+          = td style="padding: 0 15px 0 0;"
+            1995
+          = td style="padding: 0 15px;"
+            PHP
+          = td style="padding: 0 0 0 15px;"
+            C, Shell Unix
+        = tr
+          = td style="padding: 0 15px 0 0;"
+            1995
+          = td style="padding: 0 15px;"
+            JavaScript
+          = td style="padding: 0 0 0 15px;"
+            Scheme, Self
+      = mj-invoice format="0,00.00€" intl="name:Product Name"
+        = mj-invoice-item name="TV" price="549€" quantity="1"
+        = mj-invoice-item name="DVD - Iron Man II" price="22.99€" quantity="2"
+      = mj-social
+      = mj-button
+        My button
+      = mj-text
+        My text
+      = mj-image src="https://mjml.io/assets/img/logo-picto-small.png"
+      = mj-html
+        = table
+          = tr
+            = td
+              My Html
+      = mj-divider
+      = mj-raw
+        <% if (undefined) {} %>

--- a/test/assets/section.mjml.ft
+++ b/test/assets/section.mjml.ft
@@ -1,0 +1,2 @@
+=     mj-body
+  = mj-section

--- a/test/assets/sectionWithTextAlign.mjml.ft
+++ b/test/assets/sectionWithTextAlign.mjml.ft
@@ -1,0 +1,2 @@
+= mj-body
+  = mj-section text-align="left"


### PR DESCRIPTION
Now we can use a fast similar slim tag. I named it SpeedyTag and i used .mjml.fit extension to distinct .mjml file. But that doesn't matter. You just need to use SpeedyTag format in a file. 
It's based on mjml tags. 
See files examples in test/assets.  You can use same commands lines to render a html file and give the right file. 
