### PR TITLE
Fix Outlook VML Background.

### DIFF
--- a/src/mjml2html.js
+++ b/src/mjml2html.js
@@ -82,7 +82,7 @@ const fixOutlookLayout = $ => {
 
     $(this).before(`<!--[if gte mso 9]>
       <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:${width}px;">
-        <v:fill origin="0.5, 0" position="0.5,0" type="tile" src="${url}" />
+        <v:fill origin="0.5, 0" position="0.5,0" type="frame" src="${url}" />
         <v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0">
       <![endif]-->`)
 


### PR DESCRIPTION
Changed <v:fill type from type="tile" to type ="frame".
A 600px background will now be displayed correct on a 600px section.

The issue:
When using a background image smaller than the size of the section, it will be stretched to fit when using type="frame".

-> Need to utilize background-size or background-repeat to decide if frame ot tile is used.
I'd appreciate your advice here on which to use and how to keep thing compatible.

**Please dont merge this before we can make sure that it wont break backgrounds for many others.**
