### PR TITLE
Added default values for invoice price and quantity

### DIFF
--- a/src/components/Invoice/index.js
+++ b/src/components/Invoice/index.js
@@ -102,8 +102,8 @@ class Invoice extends Component {
     const currency = this.currency
 
     const total = this.items.reduce((prev, item) => {
-      const unitPrice = parseFloat(numeral().unformat(item.getIn(['attributes', 'price'])))
-      const quantity = parseInt(item.getIn(['attributes', 'quantity']))
+      const unitPrice = parseFloat(numeral().unformat(item.getIn(['attributes', 'price']))) || 0
+      const quantity = parseInt(item.getIn(['attributes', 'quantity'])) || 1
 
       return prev + unitPrice * quantity
     }, 0)


### PR DESCRIPTION
When user do not provide valid values for `mj-invoice-item` object mjml results in error.

Covered cases
```
<mj-invoice-item name="Some name" price="123" quantity="" />
<mj-invoice-item name="Some name" price="123" quantity="not-int" />
```

https://mjml.io/try-it-live/dac50d64d46b4c376dba3f449483faa0