### PR TITLE
Fix unwanted margin under Divider in MSO 2013

### DIFF
--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -21,7 +21,7 @@ const baseStyles = {
 }
 const postRender = $ => {
   $('.mj-divider-outlook').each(function () {
-    const insertNode = `<table align="center" border="0" cellpadding="0" cellspacing="0" style="${$(this).attr('style')}" width="${$(this).data('divider-width')}"><tr><td>&nbsp;</td></tr></table>`
+    const insertNode = `<table align="center" border="0" cellpadding="0" cellspacing="0" style="${$(this).attr('style')}" width="${$(this).data('divider-width')}"><tr><td style="height:0;line-height:0;">&nbsp;</td></tr></table>`
 
     $(this)
       .removeAttr('data-divider-width')


### PR DESCRIPTION
The following mjml
```
  <mj-section padding="0">
    <mj-column
      background-color="#e17000">
      <mj-text padding="0 20px"
               font-family="Verdana, Arial, sans-serif"
               font-size="10"
               line-height="30px"
               color="#ffffff">
        &nbsp;
      </mj-text>
      <mj-divider padding="0"
                  border-width="3px"
                  border-style="solid"
                  border-color="#f6d4b2" />
    </mj-column>
  </mj-section>
```
will result in a dark-orange banner (with possible white text) and a light orange 3px divider on the bottom.
But in Outlook 2013 a small dark line will appear under the divider (gets an extra margin). Bug found in native Outlook 2013 and reproduced in Litmus.com. Fix worked in litmus.com.