### PR TITLE
fix mjml-social align attribute

### DIFF
--- a/packages/mjml-social/src/index.js
+++ b/packages/mjml-social/src/index.js
@@ -49,7 +49,8 @@ const baseStyles = {
     margin: 0
   },
   td1: {
-    verticalAlign: 'middle'
+    verticalAlign: 'middle',
+    padding: '4px'
   },
   td2:  {
     verticalAlign: 'middle'
@@ -134,9 +135,6 @@ class Social extends Component {
         fontWeight: mjAttribute('font-weight'),
         lineHeight: defaultUnit(mjAttribute('line-height'), "px"),
         textDecoration: mjAttribute('text-decoration')
-      },
-      td1: {
-        padding: '4px'
       },
       td2: {
         width: defaultUnit(mjAttribute('icon-size'), "px"),

--- a/packages/mjml-social/src/index.js
+++ b/packages/mjml-social/src/index.js
@@ -41,21 +41,17 @@ const defaultMJMLDefinition = {
 }
 const columnElement = true
 const baseStyles = {
-  div: {
-    textAlign: 'center'
-  },
   tableHorizontal: {
     float: 'none',
     display: 'inline-table'
   },
   tableVertical: {
-    margin: '0 auto'
+    margin: 0
   },
   td1: {
     verticalAlign: 'middle'
   },
   td2:  {
-    textAlign: 'center',
     verticalAlign: 'middle'
   },
   tdText: {
@@ -129,9 +125,6 @@ class Social extends Component {
     const { mjAttribute, defaultUnit } = this.props
 
     return merge({}, baseStyles, {
-      div: {
-        textAlign: mjAttribute('align')
-      },
       a: {
         color: mjAttribute('color'),
         fontFamily: mjAttribute('font-family'),
@@ -139,10 +132,11 @@ class Social extends Component {
         fontStyle: mjAttribute('font-style'),
         fontWeight: mjAttribute('font-weight'),
         lineHeight: defaultUnit(mjAttribute('line-height'), "px"),
-        textDecoration: mjAttribute('text-decoration')
+        textDecoration: mjAttribute('text-decoration'),
+        textAlign: "left"
       },
       td1: {
-        padding: this.isHorizontal() ? '0 4px' : '4px 0'
+        padding: '4px'
       },
       td2: {
         width: defaultUnit(mjAttribute('icon-size'), "px"),
@@ -184,7 +178,8 @@ class Social extends Component {
             style={iconStyle}>
             <tbody>
               <tr>
-                <td style={this.styles.td2}>
+                <td
+                  style={this.styles.td2}>
                   <a href={href}>
                     <img
                       alt={platform}
@@ -254,7 +249,7 @@ class Social extends Component {
         <table
           cellPadding="0"
           cellSpacing="0"
-          data-legacy-align="left"
+          data-legacy-align={mjAttribute('align')}
           data-legacy-border="0"
           key={`wrapped-social-button-${index}`}
           style={this.styles.tableHorizontal}>
@@ -268,7 +263,7 @@ class Social extends Component {
       result.push(<div className="mj-social-outlook-line" key={`outlook-line-${index}`} />)
 
       return result
-    }, [<div className="mj-social-outlook-open" key="outlook-open" data-align={mjAttribute('align')} />])
+    }, [<div className="mj-social-outlook-open" key="outlook-open" data-legacy-align={mjAttribute('align')} />])
 
     socialButtons[socialButtons.length - 1] = <div className="mj-social-outlook-close" key="outlook-close" />
 
@@ -276,12 +271,14 @@ class Social extends Component {
   }
 
   renderVertical () {
+    const { mjAttribute } = this.props
+
     return (
       <table
         cellPadding="0"
         cellSpacing="0"
-        data-legacy-align="center"
         data-legacy-border="0"
+        data-legacy-align={mjAttribute('align')}
         style={this.styles.tableVertical}>
         <tbody>
           {this.renderSocialButtons()}
@@ -292,7 +289,7 @@ class Social extends Component {
 
   render () {
     return (
-      <div style={this.styles.div}>
+      <div>
         { this.isHorizontal() ? this.renderHorizontal() : this.renderVertical() }
       </div>
     )

--- a/packages/mjml-social/src/index.js
+++ b/packages/mjml-social/src/index.js
@@ -60,6 +60,7 @@ const baseStyles = {
   },
   a: {
     textDecoration: 'none',
+    textAlign: "left",
     display: 'block',
     borderRadius: '3px'
   },
@@ -132,8 +133,7 @@ class Social extends Component {
         fontStyle: mjAttribute('font-style'),
         fontWeight: mjAttribute('font-weight'),
         lineHeight: defaultUnit(mjAttribute('line-height'), "px"),
-        textDecoration: mjAttribute('text-decoration'),
-        textAlign: "left"
+        textDecoration: mjAttribute('text-decoration')
       },
       td1: {
         padding: '4px'


### PR DESCRIPTION
  - Fix mj-social align attribute

<p align="center">
<img width="602" alt="screen shot 2016-05-17 at 18 47 48" src="https://cloud.githubusercontent.com/assets/1830348/15331121/107d398e-1c60-11e6-9205-b6a0c7e63699.png">
</p>

Test:

```
  <mjml>
    <mj-body>
    <mj-container>
      <mj-section padding="0">
        <mj-column background-color="red">
          <mj-image src="https://gallery.mailchimp.com/4f7f09ba14cf6985588b289cf/images/d3a2ff0f-a1f5-434b-aeb6-b22ea442b374.gif" alt="Icône coeur et mains" width="74" height="69" align="center"></mj-image>
        </mj-column>
        <mj-column background-color="yellow">
          <mj-social
            align="right"
            mode="vertical"
            display="google facebook"
            google-icon-color="#424242"
            facebook-icon-color="#424242"
            facebook-href="My facebook page"
            google-href="My google+ page" />
        </mj-column>
      </mj-section>
      <mj-section padding="0">
        <mj-column background-color="green">
          <mj-social
            align="left"
            mode="vertical"
            display="google facebook"
            google-icon-color="#424242"
            facebook-icon-color="#424242"
            facebook-href="My facebook page"
            google-href="My google+ page" />
        </mj-column>
      </mj-section>
        <mj-section padding="0">
          <mj-column background-color="green">
            <mj-social
              align="center"
              mode="horizontal"
              display="google facebook"
              google-icon-color="#424242"
              facebook-icon-color="#424242"
              facebook-href="My facebook page"
              google-href="My google+ page" />
          </mj-column>
        </mj-section>
      </mj-container>
    </mj-body>
  </mjml>
```