### PR TITLE
Inclusion of text-transform for mjml-link

### DIFF
--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -162,17 +162,18 @@ Displays a horizontal navbar.
   All the mj-link components must be wrapped in a component mj-inline-links
 </aside>
 
-attribute        | unit          | description                    | default value
------------------|---------------|--------------------------------|------------------------------
-color            | color         | text color                     | #000000
-font-family      | string        | font                           | Ubuntu, Helvetica, Arial, sans-serif
-font-size        | px            | text size                      | 13px
-font-style       | string        | normal/italic/oblique          | n/a
-font-weight      | number        | text thickness                 | n/a
-line-height      | px            | space between the lines        | 22px
-text-decoration  | string        | underline/overline/none        | n/a
-padding          | px            | supports up to 4 parameters    | 10px 25px
-padding-top      | px            | top offset                     | n/a
-padding-bottom   | px            | bottom offset                  | n/a
-padding-left     | px            | left offset                    | n/a
-padding-right    | px            | right offset                   | n/a
+attribute        | unit          | description                           | default value
+-----------------|---------------|---------------------------------------|------------------------------
+color            | color         | text color                            | #000000
+font-family      | string        | font                                  | Ubuntu, Helvetica, Arial, sans-serif
+font-size        | px            | text size                             | 13px
+font-style       | string        | normal/italic/oblique                 | n/a
+font-weight      | number        | text thickness                        | n/a
+line-height      | px            | space between the lines               | 22px
+text-decoration  | string        | underline/overline/none               | n/a
+text-transform   | string        | capitalize/uppercase/lowercase/none   | uppercase
+padding          | px            | supports up to 4 parameters           | 10px 25px
+padding-top      | px            | top offset                            | n/a
+padding-bottom   | px            | bottom offset                         | n/a
+padding-left     | px            | left offset                           | n/a
+padding-right    | px            | right offset                          | n/a

--- a/packages/mjml-navbar/src/Link.js
+++ b/packages/mjml-navbar/src/Link.js
@@ -54,6 +54,7 @@ class Link extends Component {
         fontWeight: mjAttribute('font-weight'),
         lineHeight: mjAttribute('line-height'),
         textDecoration: mjAttribute('text-decoration'),
+        textTransform: mjAttribute('text-transform'),
         padding: mjAttribute('padding'),
         paddingTop: mjAttribute('padding-top'),
         paddingLeft: mjAttribute('padding-left'),


### PR DESCRIPTION
The key objective of the change is to allow markup to dictate
text-transform as it is not desirable in all cases to have links
converted to uppercase without editors ability to change.