### PR TITLE
Add "border-radius" attribute to mj-image

### DIFF
--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -33,6 +33,7 @@ padding-left                  | px            | left offset                    |
 padding-right                 | px            | right offset                   | n/a
 container-background-color    | color         | inner element background color | n/a
 border                        | string        | css border definition          | none
+border-radius                 | px            | border radius                  | 0px
 width                         | px            | image width                    | 100%
 height                        | px            | image height                   | auto
 src                           | url           | image source                   | n/a

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -33,7 +33,7 @@ padding-left                  | px            | left offset                    |
 padding-right                 | px            | right offset                   | n/a
 container-background-color    | color         | inner element background color | n/a
 border                        | string        | css border definition          | none
-border-radius                 | px            | border radius                  | 0px
+border-radius                 | px            | border radius                  | n/a
 width                         | px            | image width                    | 100%
 height                        | px            | image height                   | auto
 src                           | url           | image source                   | n/a

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -11,6 +11,7 @@ const defaultMJMLDefinition = {
     'align': 'center',
     'alt': '',
     'border': 'none',
+    'border-radius': '0px',
     'href': '',
     'src': '',
     'target': '_blank'
@@ -25,6 +26,7 @@ const baseStyles = {
   },
   img: {
     border: 'none',
+    borderRadius: '0px',
     display: 'block',
     outline: 'none',
     textDecoration: 'none',
@@ -51,7 +53,7 @@ class Image extends Component {
   }
 
   getStyles () {
-    const { mjAttribute } = this.props
+    const { mjAttribute, defaultUnit } = this.props
 
     return merge({}, baseStyles, {
       td: {
@@ -59,7 +61,8 @@ class Image extends Component {
       },
       img: {
         border: mjAttribute('border'),
-        height: mjAttribute('height')
+        height: mjAttribute('height'),
+        borderRadius: defaultUnit(mjAttribute('border-radius'), "px")
       }
     })
   }

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -11,7 +11,7 @@ const defaultMJMLDefinition = {
     'align': 'center',
     'alt': '',
     'border': 'none',
-    'border-radius': '0px',
+    'border-radius': '',
     'href': '',
     'src': '',
     'target': '_blank'
@@ -26,7 +26,7 @@ const baseStyles = {
   },
   img: {
     border: 'none',
-    borderRadius: '0px',
+    borderRadius: '',
     display: 'block',
     outline: 'none',
     textDecoration: 'none',


### PR DESCRIPTION
I'd like to add rounded photo images in HTML email, so I created this pull request.