### PR TITLE
Adding date to console log

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -108,7 +108,8 @@ export const renderStream = options => render(readStdin(process.stdin), options)
  */
 export const watch = (input, options) => {
   renderFile(input, options)
-  fs.watchFile(input, () => console.log(`${new Date()} Reloading MJML`) || renderFile(input, options)) // eslint-disable-line no-console
+  let now = new Date();
+  fs.watchFile(input, () => console.log(`[${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}] Reloading MJML`) || renderFile(input, options)) // eslint-disable-line no-console
 }
 
 /*

--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -108,7 +108,7 @@ export const renderStream = options => render(readStdin(process.stdin), options)
  */
 export const watch = (input, options) => {
   renderFile(input, options)
-  fs.watchFile(input, () => console.log(new Date() + 'Reloading MJML') || renderFile(input, options)) // eslint-disable-line no-console
+  fs.watchFile(input, () => console.log(`${new Date()} Reloading MJML`) || renderFile(input, options)) // eslint-disable-line no-console
 }
 
 /*

--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -108,7 +108,7 @@ export const renderStream = options => render(readStdin(process.stdin), options)
  */
 export const watch = (input, options) => {
   renderFile(input, options)
-  let now = new Date();
+  const now = new Date();
   fs.watchFile(input, () => console.log(`[${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}] Reloading MJML`) || renderFile(input, options)) // eslint-disable-line no-console
 }
 

--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -108,7 +108,7 @@ export const renderStream = options => render(readStdin(process.stdin), options)
  */
 export const watch = (input, options) => {
   renderFile(input, options)
-  fs.watchFile(input, () => console.log('Reloading MJML') || renderFile(input, options)) // eslint-disable-line no-console
+  fs.watchFile(input, () => console.log(new Date() + 'Reloading MJML') || renderFile(input, options)) // eslint-disable-line no-console
 }
 
 /*


### PR DESCRIPTION
It's not currently possible to see when the last compilation happened. Just adds the default date and time to the console log.

Further improvements is to show compilation time details etc, a la `gulp-sass`