### PR TITLE
Expand MJML acronym in ReadMe to avoid ambiguity; add supporting image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@
 
 ---
 
+# Michael Jackson Markdown Language
+
+<p align="center">
+  <a href="http://mjml.io" target="_blank">
+    <img src="http://www.fanvasion.com/index/images/latestnews/michaeltribute.png">
+  </a>
+</p>
+
+---
+
 # Introduction
 
 MJML is a markup language designed to reduce the pain of coding a responsive email. Its semantic syntax makes it easy and straightforward while its rich standard components library fastens your development time and lightens your email codebase. MJML’s open-source engine takes care of translating the MJML you wrote into responsive HTML.


### PR DESCRIPTION
Props for building such a brilliant module - this has made some traumatized friends of mine incredibly happy and there seems to be an overwhelming sense of relief that we don't have to write mind-numbing table-within-table html anymore when tasked with simple email templating work. 

"MJML" tho.
A month ago, after a bunch of discussion, we decided unanimously that MJML had to be short for Michael Jackson Markdown Language. We were always getting our tongues tied in trying to remember the acronym before this point, but after a tipsy jam to 'Thriller' the name Michael Jackson Markdown Language became unforgettable. 
Friday has rolled around again, and it's been a huge let-down for us to find the apparent extended title for this magical module is something as disappointing as Mail-Jet Markdown Language. I've made a quick fix to aid in fixing memorization of the module name in hope that others can have the same appreciation that we've had in the office for the past month.
