### PR TITLE
Fix mjml-button text display on older outlook versions

### DIFF
--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -26,7 +26,6 @@ const baseStyles = {
     borderCollapse: 'separate'
   },
   a: {
-    display: 'inline-block',
     textDecoration: 'none'
   }
 }

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -26,7 +26,8 @@ const baseStyles = {
     borderCollapse: 'separate'
   },
   a: {
-    textDecoration: 'none'
+    textDecoration: 'none',
+    lineHeight: '100%'
   }
 }
 


### PR DESCRIPTION
By removing the display:inline-block property

Fix #385 