### PR TITLE
Prevent same ending tag to be stored multiple times

### DIFF
--- a/packages/mjml-core/src/MJMLElementsCollection.js
+++ b/packages/mjml-core/src/MJMLElementsCollection.js
@@ -1,4 +1,5 @@
 import warning from 'warning'
+import { includes } from 'lodash'
 
 export const endingTags = []
 export const postRenders = []
@@ -10,7 +11,7 @@ export const registerMJElement = Component => {
     return warning(false, 'Component has no TagName')
   }
 
-  endingTag  && !endingTags.includes(tagName) && endingTags.push(tagName)
+  endingTag  && !includes(endingTags, tagName) && endingTags.push(tagName)
   postRender && postRenders.push(postRender)
 
   MJMLElementsCollection[tagName] = Component

--- a/packages/mjml-core/src/MJMLElementsCollection.js
+++ b/packages/mjml-core/src/MJMLElementsCollection.js
@@ -10,7 +10,7 @@ export const registerMJElement = Component => {
     return warning(false, 'Component has no TagName')
   }
 
-  endingTag  && endingTags.push(tagName)
+  endingTag  && !endingTags.includes(tagName) && endingTags.push(tagName)
   postRender && postRenders.push(postRender)
 
   MJMLElementsCollection[tagName] = Component


### PR DESCRIPTION
As module variables are singleton, there is a risk for the same endingTag to be pushed multiple times while calling registerMJElement multiple times (e.g: having a unit test in watch mode, requiring the same module again and again).