### PR TITLE
Added vertical-align to Hero.js defaultMJMLDefinition

### DIFF
--- a/packages/mjml-hero/src/Hero.js
+++ b/packages/mjml-hero/src/Hero.js
@@ -17,7 +17,8 @@ const defaultMJMLDefinition = {
     'padding-left': null,
     'padding-right': null,
     'padding-top': null,
-    'background-color': '#ffffff'
+    'background-color': '#ffffff',
+    'vertical-align': 'top'
   }
 }
 


### PR DESCRIPTION
`vertical-align` support was added on `mjml-hero` by https://github.com/mjmlio/mjml/pull/372/commits/4329fec0009bf55340324b1013bd02233af41df5 and it worked fine since then.

Testing the upgrade to MJML 3.0.0, I now get the following warning: `Line XY (mj-hero) — Attribute vertical-align is illegal`.

As far as I understand `mjml-validator` was changed in the meantime (definitely did not get this with MJML 2.3.3) as the error comes from `mjml-validator/src/rules/validAttributes.js` who gets the `avalaibleAttributes` from `defaultMJMLDefinition` .

I've not yet tested if this fix is sufficient but I'll update the pull request as needed.

Are there tests for the individual MJML components ?