### PR TITLE
Make mjml render in the browser.

### DIFF
--- a/packages/mjml-core/src/parsers/document.js
+++ b/packages/mjml-core/src/parsers/document.js
@@ -58,8 +58,14 @@ const mjmlElementParser = (elem, content) => {
 const parseHead = (head, attributes) => {
   const $container = dom.parseHTML(attributes.container)
 
-  each(compact(filter(dom.getChildren(head), child => child.tagName)), element => {
-    const handler = MJMLHeadElements[element.tagName.toLowerCase()]
+  each(compact(filter(dom.getChildren(head), child => child.tagName)), el => {
+    const element = {
+      attributes: dom.getAttributes(el),
+      children: el.children,
+      tagName: el.tagName.toLowerCase(),
+    };
+
+    const handler = MJMLHeadElements[element.tagName]
 
     if (handler) {
       handler(element, { $container, ...attributes })

--- a/packages/mjml-core/src/parsers/document.js
+++ b/packages/mjml-core/src/parsers/document.js
@@ -2,6 +2,7 @@ import { ParseError, EmptyMJMLError, NullElementError } from '../Error'
 import compact from 'lodash/compact'
 import dom from '../helpers/dom'
 import each from 'lodash/each'
+import toArray from 'lodash/toArray';
 import filter from 'lodash/filter'
 import { endingTags } from '../MJMLElementsCollection'
 import MJMLHeadElements from '../MJMLHead'
@@ -61,7 +62,7 @@ const parseHead = (head, attributes) => {
   each(compact(filter(dom.getChildren(head), child => child.tagName)), el => {
     const element = {
       attributes: dom.getAttributes(el),
-      children: el.children,
+      children: toArray(el.childNodes),
       tagName: el.tagName.toLowerCase(),
     };
 

--- a/packages/mjml-head-attributes/src/index.js
+++ b/packages/mjml-head-attributes/src/index.js
@@ -5,10 +5,10 @@ import omit from 'lodash/omit'
 
 export default {
   name: "mj-attributes",
-  handler: ($, { defaultAttributes, cssClasses }) => {
-    each(compact(filter($.children, child => child.tagName)), elem => {
-      const tagName = elem.tagName.toLowerCase()
-      const attributes = elem.attribs
+  handler: (element, { defaultAttributes, cssClasses }) => {
+    each(compact(filter(element.children, child => child.tagName)), elem => {
+      const tagName = element.tagName
+      const attributes = element.attributes;
 
       if (tagName === 'mj-class') {
         return cssClasses[attributes.name] = omit(attributes, ['name'])

--- a/packages/mjml-head-font/src/index.js
+++ b/packages/mjml-head-font/src/index.js
@@ -1,14 +1,14 @@
-import _ from "lodash"
+import find from "lodash/find"
 
 export default {
   name: "mj-font",
-  handler: (el, { fonts }) => {
-    const font = _.find(fonts, ['name', el.attribs.name])
+  handler: (element, { fonts }) => {
+    const font = find(fonts, ['name', element.attributes.name])
 
     if (font) {
-      font.url = el.attribs.href
+      font.url = element.attributes.href
     } else {
-      fonts.push({ name: el.attribs.name, url: el.attribs.href })
+      fonts.push({ name: element.attributes.name, url: element.attributes.href })
     }
   }
 }

--- a/packages/mjml-head-style/src/index.js
+++ b/packages/mjml-head-style/src/index.js
@@ -1,7 +1,7 @@
 export default {
   name: "mj-style",
   handler: (el, { css }) => {
-    const innerText = el.children.map(child => child.type === 'text' && child.data).join('')
+    const innerText = el.children.map(child => (child.type === 'text' || child.nodeType === Node.TEXT_NODE) && child.data).join('')
 
     css.push(innerText)
   }

--- a/packages/mjml-head-title/src/index.js
+++ b/packages/mjml-head-title/src/index.js
@@ -1,7 +1,7 @@
 export default {
   name: "mj-title",
   handler: (el, { $container }) => {
-    const innerText = el.children.map(child => child.type === 'text' && child.data).join('')
+    const innerText = el.children.map(child => (child.type === 'text' || child.nodeType === Node.TEXT_NODE) && child.data).join('')
 
     $container('title').text(innerText)
   }


### PR DESCRIPTION
parseHead() now gets the element attributes using dom.getAttributes() and passes them to the handler in the same way as mjmlElementParser does. I've updated the attributes and font tags to use the newly passed attributes object.

Helps with #274 & fixes #395