### PR TITLE
Allow setting the height of a mjml text container

### DIFF
--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -38,6 +38,7 @@ This tag allows you to display text in your email.
  font-style                   | string        | normal/italic/oblique          | n/a
  font-weight                  | number        | text thickness                 | n/a
  line-height                  | px            | space between the lines        | 22px
+ height                       | px            | The height of the element      | n/a
  text-decoration              | string        | underline/overline/none        | n/a
  text-transform               | string        | uppercase/lowercase/capitalize | n/a
  align                        | string        | left/right/center              | left

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -15,6 +15,7 @@ const defaultMJMLDefinition = {
     'font-style': null,
     'font-weight': null,
     'line-height': '22px',
+    'height': null,
     'padding-bottom': null,
     'padding-left': null,
     'padding-right': null,
@@ -47,6 +48,7 @@ class Text extends Component {
         fontStyle: mjAttribute('font-style'),
         fontWeight: mjAttribute('font-weight'),
         lineHeight: defaultUnit(mjAttribute('line-height'), "px"),
+        height: defaultUnit(mjAttribute('height'), "px"),
         textAlign: mjAttribute('align'),
         textDecoration: mjAttribute('text-decoration'),
         textTransform: mjAttribute('text-transform')


### PR DESCRIPTION
This allows setting the height of a `<mj-text>` element. Especially for grid based layout this can be useful, such that each element in the grid has the same height, regardless of the number of characters in the `<mj-text>`