### PR TITLE
Add valid children information to mj-column

### DIFF
--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -3,7 +3,7 @@
 Columns enable you to horizontally organize the content within your sections. They must be located under `mj-section` tags in order to be considered by the engine.
 To be responsive, columns are expressed in terms of percentage.
 
-Every single column has to contain something because they are responsive containers, and will be vertically stacked on a mobile view.
+Every single column has to contain something because they are responsive containers, and will be vertically stacked on a mobile view. Any standard component, or component that you have defined and registered, can be placed within a column – except `mj-column` or `mj-section` elements.
 
 ```xml
 <mjml>


### PR DESCRIPTION
Just a repeat of the [nesting info](https://mjml.io/documentation/#nesting) in `mj-column`'s part of the docs, so I absolutely _can't_ miss it.