### PR TITLE
Fix escaping servers which replace the `&nbsp;` with a space

### DIFF
--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -28,7 +28,8 @@ class Spacer extends Component {
     return {
       div: {
         fontSize: '1px',
-        lineHeight: defaultUnit(mjAttribute('height'))
+        lineHeight: defaultUnit(mjAttribute('height')),
+        whiteSpace: 'nowrap'
       }
     }
   }


### PR DESCRIPTION
We have seen some servers which replace the non-breaking space character with an actual space.
This should ensure that even when there is a space the div actually renders