### PR TITLE
Allow disabling of blue links in iOS

### DIFF
--- a/packages/mjml-core/src/configs/defaultStyle.js
+++ b/packages/mjml-core/src/configs/defaultStyle.js
@@ -7,4 +7,12 @@ export default `
   table, td { border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
   img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
   p { display: block; margin: 13px 0; }
+  .no-blue-link-ios a[x-apple-data-detectors] {
+    color: inherit !important;
+    text-decoration: none !important;
+    font-size: inherit !important;
+    font-family: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+}
 `

--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -43,6 +43,7 @@ This tag allows you to display text in your email.
  text-decoration              | string        | underline/overline/line-through/none        | n/a
  text-transform               | string        | uppercase/lowercase/capitalize              | n/a
  align                        | string        | left/right/center                           | left
+ allow-autolink               | boolean       | true/false. Disables the blue links in iOS  | true
  container-background-color   | color         | inner element background color              | n/a
  padding                      | px            | supports up to 4 parameters                 | 10px 25px
  padding-top                  | px            | top offset                                  | n/a

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -8,6 +8,7 @@ const defaultMJMLDefinition = {
   content: '',
   attributes: {
     'align': 'left',
+    'allow-autolink': true,
     'color': '#000000',
     'container-background-color': null,
     'font-family': 'Ubuntu, Helvetica, Arial, sans-serif',
@@ -78,7 +79,14 @@ class Text extends Component {
   render () {
     const { mjAttribute, mjContent } = this.props
 
-    const classNames = mjAttribute('height') ? 'mj-text-height' : ''
+    const classNames = []
+    if (mjAttribute('height')) {
+      classNames.push('mj-text-height')
+    }
+    if (["false", false].includes(mjAttribute('allow-autolink'))) {
+      classNames.push('no-blue-link-ios')
+    }
+
 
     return (
       <div


### PR DESCRIPTION
Whenever we send email containing user generated data, sometimes text and links may be colored blue on iOS.

Usually we do not want this to happen. Previously we added the following css to the head of the email to circumvent this

```css
a[x-apple-data-detectors] {
    color: inherit !important;
    text-decoration: none !important;
    font-size: inherit !important;
    font-family: inherit !important;
    font-weight: inherit !important;
    line-height: inherit !important;
}
```

As a solution I've added this flag to the `mj-text` component. If the flag is set, iOS will not try to style these automatically generated links

Litmus example (note how the magnet.me in the text is not autolinked, whereas I let it autolink near the footer

https://litmus.com/builder/b0b07bc