### PR TITLE
Gave that error message more meaning

### DIFF
--- a/packages/mjml-core/src/parsers/document.js
+++ b/packages/mjml-core/src/parsers/document.js
@@ -106,7 +106,7 @@ const documentParser = (content, attributes) => {
   }
 
   if (!body || body.length < 1) {
-    throw new EmptyMJMLError('No root "<mjml>" or "<mj-body>" found in the file, or "<mj-body>" is empty')
+    throw new EmptyMJMLError('No root "<mjml>" or "<mj-body>" found in the file, or "<mj-body>" doesn\'t contain a child element.')
   }
 
   if (head && head.length === 1) {


### PR DESCRIPTION
If \<mj-body\> contains just text the element is not "empty" but the parsing still fails.