### PR TITLE
Use stdout to output if stdin is used and no output file is specified

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -51,7 +51,7 @@ const render = (bufferPromise, { min, output, stdout, fileName, level }) => {
         handleError(availableErrorOutputFormat['text'](errors))
       }
 
-      if (stdout) {
+      if (stdout || (!output)) {
         process.stdout.write(html)
       } else {
         return write(output, html)


### PR DESCRIPTION
Use stdout to output if stdin is used for input and no output file is specified.

Otherwise, if we run `mjml -i` without `-s`, we will run into errors.