### PR TITLE
Better Output Logic

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -51,10 +51,15 @@ const render = (bufferPromise, { min, output, stdout, fileName, level }) => {
         handleError(availableErrorOutputFormat['text'](errors))
       }
 
-      if (stdout || (!output)) {
+      if (!(stdout || output)) {
         process.stdout.write(html)
       } else {
-        return write(output, html)
+        if (stdout) {
+          process.stdout.write(html)
+        }
+        if (output) {
+          return write(output, html)
+        }
       }
     })
     .catch(e => {

--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -51,7 +51,7 @@ const render = (bufferPromise, { min, output, stdout, fileName, level }) => {
         handleError(availableErrorOutputFormat['text'](errors))
       }
 
-      if (stdout) {
+      if (stdout || (!output)) {
         process.stdout.write(html)
       } else {
         return write(output, html)


### PR DESCRIPTION
This patch fixes two things:

1. Originally, `-o` and `-s` cannot be used simultaneously;
2. Originally, if we specify `-i` without `-o` or `-s`, it will run into errors.

With this patch, it will first check that, if there's no filename and no output stream specified, it will automatically output to stdout. After that, it will check filename and stdout separately.