### PR TITLE
Increase the line height in mj-button so charachters are not cut off on multiline buttons

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -42,6 +42,7 @@ font-style                  | string      | normal/italic/oblique               
 font-size                   | px          | text size                                        | 13px
 font-weight                 | number      | text thickness                                   | bold
 font-family                 | string      | font name                                        | Ubuntu, Helvetica, Arial, sans-serif
+line-height                 | px or %     | line height of the text in the button            | 120%
 color                       | color       | text color                                       | #ffffff
 text-decoration             | string      | underline/overline/none                          | none
 text-transform              | string      | capitalize/uppercase/lowercase                   | none

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -41,7 +41,7 @@ const baseStyles = {
   },
   a: {
     textDecoration: 'none',
-    lineHeight: '100%'
+    lineHeight: '1.2'
   }
 }
 

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -32,7 +32,8 @@ const defaultMJMLDefinition = {
     "padding-left": null,
     "padding-right": null,
     "width": null,
-    "height": null
+    "height": null,
+    "line-height": '120%'
   }
 }
 const baseStyles = {
@@ -40,8 +41,7 @@ const baseStyles = {
     borderCollapse: 'separate'
   },
   a: {
-    textDecoration: 'none',
-    lineHeight: '1.2'
+    textDecoration: 'none'
   }
 }
 
@@ -77,6 +77,7 @@ class Button extends Component {
         fontSize: defaultUnit(mjAttribute('font-size')),
         fontStyle: mjAttribute('font-style'),
         fontWeight: mjAttribute('font-weight'),
+        lineHeight: defaultUnit(mjAttribute('line-height'), "%"),
         textDecoration: mjAttribute('text-decoration'),
         textTransform: mjAttribute('text-transform'),
         margin: "0px"


### PR DESCRIPTION
We just received work that on some email clients the text on buttons would be slightly cut off

![example](https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/65597/4562056/aw8PXXeTVk09pWo/Screenshot_2017-02-04-09-59-15.png)

Since this obviously looks bad, I quickly dove into this, and as it turns out a slight additional line-height is required (font-size and line-height do not match up exactly). By increasing this from 100% to 120% the issues are resolved (under multiple fonts)

Litmus test: https://litmus.com/checklist/emails/public/799bfc8