### PR TITLE
Replace all instances of $ character when sanitizing template string

### DIFF
--- a/packages/mjml-core/src/parsers/document.js
+++ b/packages/mjml-core/src/parsers/document.js
@@ -30,7 +30,7 @@ const safeEndingTags = content => {
     MJElements.push(tagName)
   })
 
-  let safeContent = parseAttributes(MJElements, content.replace('$', '&#36;'))
+  let safeContent = parseAttributes(MJElements, content.replace(/\$/g, '&#36;'))
 
   concat(endingTags, headEndingTags).forEach(tag => {
     safeContent = safeContent.replace(regexTag(tag), dom.replaceContentByCdata(tag))


### PR DESCRIPTION
Hey guys,

I found that sanitization function replaces only first occurrence of `$` sign, so if a string with mjml markup contains multiple `$` signs, it will break compiled template string. For instance, the following markup after compilation will have `3.40` instead of `$13.40`:

```
<mjml>
    <mj-body>
        <mj-container>
            <mj-section>
                <mj-column>
                    <mj-table>
                        <tr>
                            <td>Charged:</td>
                            <td style="text-align: right;">$9.46</td>
                        </tr>
                        <tr>
                            <td>Total:</td>
                            <td style="text-align: right;">$13.40</td>
                        </tr>
                    </mj-table>
                </mj-column>
            </mj-section>
        </mj-container>
    </mj-body>
</mjml>
``` 

This PR is to replace `$` sign globally.