### PR TITLE
fix mjml-invoice total

### DIFF
--- a/packages/mjml-invoice/src/Invoice.js
+++ b/packages/mjml-invoice/src/Invoice.js
@@ -112,7 +112,7 @@ class Invoice extends Component {
     const currency = this.currency
 
     const total = this.items.reduce((prev, item) => {
-      const unitPrice = parseFloat(numeral(item.getIn(['attributes', 'price']))) || 0
+      const unitPrice = parseFloat(numeral(item.getIn(['attributes', 'price'])).value()) || 0
       const quantity = parseInt(item.getIn(['attributes', 'quantity'])) || 1
 
       return prev + unitPrice * quantity


### PR DESCRIPTION
Invoice total is always 0 (see official example: https://mjml.io/try-it-live/components/invoice)
It's caused by numeral returning a Numeral object since 2.0 (see https://runkit.com/58c04da68e605c0015ae2560/5927f509c2d9b00012779ac4)