### PR TITLE
Add thin arrows to problematic chars

### DIFF
--- a/packages/mjml-core/src/MJMLRenderer.js
+++ b/packages/mjml-core/src/MJMLRenderer.js
@@ -23,7 +23,7 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import warning from 'warning'
 
-const DANGEROUS_CHARS = ['{{', '}}', '<%', '%>', '<=', '=>', '{%', '%}', '{{{', '}}}']
+const DANGEROUS_CHARS = ['{{', '}}', '<%', '%>', '<=', '=>', '<-', '->', '{%', '%}', '{{{', '}}}']
 const SEED = Math.floor(Math.random() * 0x10000000000).toString(16)
 const PLACEHOLDER = `__MJML__${SEED}__`
 const mjmlSanitizer = (mjml) => {


### PR DESCRIPTION
Elixir (therefore, EEx) uses thin arrows extensively.

```eex
<%= for item <- items do %>
  <mj-text></mj-text>
<% end %>
```

```eex
<%= case var do %>
  <% nil -> %>
    <mj-text></mj-text>
  <% var -> %>
    <mj-text></mj-text>
<% end %>
```