### PR TITLE
Removes commas on multiple mjContent items

### DIFF
--- a/packages/mjml-core/src/decorators/MJMLElement.js
+++ b/packages/mjml-core/src/decorators/MJMLElement.js
@@ -78,12 +78,14 @@ function createComponent (ComposedComponent) {
         return trim(content)
       }
 
-      return React.Children.map(this.props.children, child => {
+      const contentItems = React.Children.map(this.props.children, child => {
         if (typeof child === 'string') {
           return child
         }
         return ReactDOMServer.renderToStaticMarkup(child)
       })
+
+      return (Array.isArray(contentItems)) ? contentItems.join("") : contentItems;
     }
 
     inheritedAttributes () {

--- a/packages/mjml-core/src/decorators/MJMLElement.js
+++ b/packages/mjml-core/src/decorators/MJMLElement.js
@@ -85,7 +85,7 @@ function createComponent (ComposedComponent) {
         return ReactDOMServer.renderToStaticMarkup(child)
       })
 
-      return (Array.isArray(contentItems)) ? contentItems.join("") : contentItems;
+      return (Array.isArray(contentItems)) ? contentItems.join("") : contentItems
     }
 
     inheritedAttributes () {

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -82,10 +82,13 @@ class Text extends Component {
 
     const classNames = cx(mjAttribute('height') ? 'mj-text-height' : '')
 
+    const content = mjContent();
+    const commaLessContent = (Array.isArray(content)) ? content.join("") : content;
+
     return (
       <div
         className={classNames}
-        dangerouslySetInnerHTML={{ __html: mjContent() }}
+        dangerouslySetInnerHTML={{ __html: commaLessContent }}
         style={this.styles.div} />
     )
   }

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -82,13 +82,10 @@ class Text extends Component {
 
     const classNames = cx(mjAttribute('height') ? 'mj-text-height' : '')
 
-    const content = mjContent();
-    const commaLessContent = (Array.isArray(content)) ? content.join("") : content;
-
     return (
       <div
         className={classNames}
-        dangerouslySetInnerHTML={{ __html: commaLessContent }}
+        dangerouslySetInnerHTML={{ __html: mjContent() }}
         style={this.styles.div} />
     )
   }


### PR DESCRIPTION
## Summary

Fixes #675 

### Changes

- ~Added a check in the text component for children being an array~
- Reverted the text component only change in favour of the core content
- Added the join to the `mjContent` method to solve for any component
- Join the array of children on an empty separator instead of letting react's `__html` automatically decide that for us and add commas.

### Linting output success

```
╰─ yarn run lint
yarn run v0.27.5
$ eslint .
Done in 7.35s.
```