### PR TITLE
Fix unwanted space after image in Outlook

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -62,6 +62,7 @@ const postRender = $ => {
       ${helpers.endConditionalTag}`)
 
     $(this).after(`${helpers.startConditionalTag}
+        <p style="margin:0;mso-hide:all"><o:p xmlns:o="urn:schemas-microsoft-com:office:office">&nbsp;</o:p></p>
         </v:textbox>
       </v:rect>
       ${helpers.endConditionalTag}`)


### PR DESCRIPTION
Solution found on litmus
https://litmus.com/community/discussions/538-vml-outlook-07-10-13-unwanted-20px-padding-at-the-bottom#comment-3947