### PR TITLE
Fix mj-social on outlook 2013 height

### DIFF
--- a/packages/mjml-social/src/index.js
+++ b/packages/mjml-social/src/index.js
@@ -67,6 +67,7 @@ const baseStyles = {
     verticalAlign: 'middle'
   },
   td2:  {
+    fontSize: '0',
     verticalAlign: 'middle'
   },
   tdText: {


### PR DESCRIPTION
Icon misbehave if they are smaller than default font size