### PR TITLE
[Hero content] float property doesn't support center

### DIFF
--- a/packages/mjml-hero/src/HeroContent.js
+++ b/packages/mjml-hero/src/HeroContent.js
@@ -15,9 +15,6 @@ const defaultMJMLDefinition = {
 const endingTag = false
 
 const baseStyles = {
-  div: {
-    float: 'center'
-  },
   table: {
     width: '100%',
     margin: '0px'


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/CSS/float

As per MDN docs, the `float: center` doesn't do anything, it would be replaced with `float: none`, however `none` is the default value making it redundant.

Happy camping.