### PR TITLE
Ensure proper line-height of mj-button

### DIFF
--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -57,7 +57,9 @@ class Button extends Component {
 
     return helpers.merge({}, baseStyles, {
       table: {
-        width: mjAttribute('width')
+        width: mjAttribute('width'),
+        // Ensure that wrong line-height wouldn't be inherited
+        lineHeight: '100%'
       },
       td: {
         border: mjAttribute('border'),


### PR DESCRIPTION
Parent `line-heigh` (from web mail client, for example) could visually broke `mj-button` vertical align

Demo from #846 

https://mjml.io/try-it-live/rkMv8LvTb