### PR TITLE
Ensure proper line-height of mj-button

### DIFF
--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -56,7 +56,6 @@ export default class MjButton extends BodyComponent {
       table: {
         'border-collapse': 'separate',
         width: this.getAttribute('width'),
-        // Ensure that wrong line-height wouldn't be inherited
         'line-height': '100%',
       },
       td: {

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -56,6 +56,8 @@ export default class MjButton extends BodyComponent {
       table: {
         'border-collapse': 'separate',
         width: this.getAttribute('width'),
+        // Ensure that wrong line-height wouldn't be inherited
+        'line-height': '100%',
       },
       td: {
         border: this.getAttribute('border'),


### PR DESCRIPTION
Parent line-heigh (from web mail client, for example) could visually broke mj-button vertical align

Demo from #846

https://mjml.io/try-it-live/rkMv8LvTb