### PR TITLE
check .mjmlconfig for custom components to validate against

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -1,4 +1,6 @@
 import { mjml2html, version, documentParser, MJMLValidator } from 'mjml-core'
+import configParser from 'mjml-core/lib/parsers/config'
+import isBrowser from 'mjml-core/lib/helpers/isBrowser'
 import fs from 'fs'
 import glob from 'glob'
 import path from 'path'
@@ -124,6 +126,9 @@ export const renderStream = options => {
  * Validate an MJML document
  */
 export const validate = (input, { format }) => {
+  if (!isBrowser()) {
+    configParser({ filePath: input })
+  }
   return read(input)
     .then(content => {
       const MJMLDocument = documentParser(content.toString())


### PR DESCRIPTION
The execution path divergence between validate and render happens in the `bin/mjml` file.  Ideally this would run before so that it doesn't have to be called in each execution path. Because of this, the PR attached is not the most elegant way of solving issue #660 , but it works.  