### PR TITLE
Enhancement — Allow mj-image to take string values

### DIFF
--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -54,6 +54,8 @@ class Image extends Component {
     const { mjAttribute, getPadding } = this.props
     const parentWidth = mjAttribute('parentWidth')
 
+    if (!mjAttribute( 'width' ).match(/\d+(px|%)?/)) return mjAttribute('width');
+
     const width = mjAttribute('width') ? min([parseInt(mjAttribute('width')), parseInt(parentWidth)]) : parseInt(parentWidth)
 
     const paddingRight = getPadding('right')


### PR DESCRIPTION
This enhancement will allow `mjml-image` to put a string directly into the markup.

The goal is to allow:

```
<mj-image
  src="{{image.src}}"
  width="{{image.width}}" />
```

To produce markup with `{{image.width}}` within it, so that it could be replaced by another templating language like Handlebars or MJML.



