### PR TITLE
allow config option to accept a JSON string

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -56,7 +56,8 @@ const argv = yargs
     },
     c: {
       alias: 'config',
-      type: 'object',
+      coerce: JSON.parse,
+      type: 'string',
       describe: 'Option to pass to mjml-core',
     },
     version: {


### PR DESCRIPTION
Fixes #871 . To use on the command line, enclose the json object in single quotes like so: `-c '{ "beautify": false}'`