### PR TITLE
(fix) add babel transform runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     "add-module-exports",
     "transform-regenerator",
     "transform-decorators-legacy",
-    "transform-async-to-generator"
+    "transform-async-to-generator",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-regenerator": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,6 +695,12 @@ babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
I believe this is also needed otherwise user will get `ReferenceError: regeneratorRuntime is not defined` same as nuxt/nuxt.js#934
Error was introduced with 3ab1c2488e1f82865802431045609b5074364904. This resolves it.
