### PR TITLE
Set minifyCSS to false

### DIFF
--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -236,7 +236,7 @@ export default function mjml2html(mjml, options = {}) {
   content = minify
     ? htmlMinify(content, {
         collapseWhitespace: true,
-        minifyCSS: true,
+        minifyCSS: false,
         removeEmptyAttributes: true,
       })
     : content


### PR DESCRIPTION
html-minifier is converting every color name to a hex-value. This causes font names like "Arial Black" to be turned into "Arial #000". Disabling minifyCSS prevents this.