### PR TITLE
mj-social: remove `icon-color` attrib from code and doc.

### DIFF
--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -12,13 +12,13 @@ Displays calls-to-action for various social networks with their associated logo.
     <mj-section>
       <mj-column>
         <mj-social font-size="15px" icon-size="30px" mode="horizontal">
-          <mj-social-element name="facebook" href="https://mjml.io/" icon-color="#4d4d4d">
+          <mj-social-element name="facebook" href="https://mjml.io/">
             Facebook
           </mj-social-element>
-          <mj-social-element name="google" href="https://mjml.io/" icon-color="#4d4d4d">
+          <mj-social-element name="google" href="https://mjml.io/">
             Google
           </mj-social-element>
-          <mj-social-element  name="instagram" href="https://mjml.io/" icon-color="#4d4d4d">
+          <mj-social-element  name="instagram" href="https://mjml.io/">
             Instagram
           </mj-social-element>
         </mj-social>

--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -12,13 +12,13 @@ Displays calls-to-action for various social networks with their associated logo.
     <mj-section>
       <mj-column>
         <mj-social font-size="15px" icon-size="30px" mode="horizontal">
-          <mj-social-element name="facebook" href="https://mjml.io/">
+          <mj-social-element name="facebook" href="https://mjml.io/" background-color="#4d4d4d">
             Facebook
           </mj-social-element>
-          <mj-social-element name="google" href="https://mjml.io/">
+          <mj-social-element name="google" href="https://mjml.io/" background-color="#4d4d4d">
             Google
           </mj-social-element>
-          <mj-social-element  name="instagram" href="https://mjml.io/">
+          <mj-social-element  name="instagram" href="https://mjml.io/" background-color="#4d4d4d">
             Instagram
           </mj-social-element>
         </mj-social>

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -52,7 +52,6 @@ export default class MjSocialElement extends BodyComponent {
     'font-style': 'string',
     'font-weight': 'string',
     href: 'string',
-    'icon-color': 'color',
     'icon-size': 'unit(px,%)',
     'line-height': 'unit(px,%)',
     name: 'string',


### PR DESCRIPTION
Setting `icon-color` on a `<mj-social-element />` has no effect. Removed from doc and from the allowed attributes list. The correct way to set a colour of the icon is via the `background-color` attribute, which is already documented.