### PR TITLE
Fix alt attribute missing from image

### DIFF
--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -89,7 +89,8 @@ export default class MjImage extends BodyComponent {
     const img = `
       <img
         ${this.htmlAttributes({
-          alt: this.getAttribute('href'),
+          alt: this.getAttribute('alt'),
+          href: this.getAttribute('href'),
           height: this.getAttribute('height'),
           src: this.getAttribute('src'),
           srcset: this.getAttribute('srcset'),

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -90,7 +90,6 @@ export default class MjImage extends BodyComponent {
       <img
         ${this.htmlAttributes({
           alt: this.getAttribute('alt'),
-          href: this.getAttribute('href'),
           height: this.getAttribute('height'),
           src: this.getAttribute('src'),
           srcset: this.getAttribute('srcset'),


### PR DESCRIPTION
Previous to this code fix adding a `href` attribute to `mj-image` would render the alt tag. 

Now adding `alt` to `mj-image` will render the alt tag as expected.

Fixes: https://github.com/mjmlio/mjml/issues/1048