### PR TITLE
fix #919 column & group use max-width to handle clients that wipe imp…

### DIFF
--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -172,7 +172,7 @@ export default function mjml2html(mjml, options = {}) {
     addMediaQuery(className, { parsedWidth, unit }) {
       globalDatas.mediaQueries[
         className
-      ] = `{ width:${parsedWidth}${unit} !important; }`
+      ] = `{ width:${parsedWidth}${unit} !important; max-width: ${parsedWidth}${unit}; }`
     },
     addHeadSyle(identifier, headStyle) {
       globalDatas.headStyle[identifier] = headStyle


### PR DESCRIPTION
…ortant tags

Tested on email-on-acid
Fixes #919 on GMX and WEB.DE, and doesn't seem to break rendering on other clients