### PR TITLE
Fix mj-social-element when inline style is added

### DIFF
--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -193,6 +193,7 @@ export default class MjSocialElement extends BodyComponent {
                 </td>
               </tr>
           </table>
+        </td>
           ${this.getContent()
             ? `
             <td ${this.htmlAttributes({ style: 'tdText' })} >
@@ -207,7 +208,6 @@ export default class MjSocialElement extends BodyComponent {
             </td>
             `
             : ''}
-        </td>
       </tr>
     `
   }


### PR DESCRIPTION
When inline style is added, the first social element is centered but the following are on the left side.

The TD tag of mj-social-element is not well closed and juice add closing tags and change the html code.

Tested with the following MJML :
```
<mjml>
  <mj-head>
    <mj-style inline="inline"></mj-style>
  </mj-head>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-social mode="horizontal">
          <mj-social-element name="facebook" href="https://mjml.io/">
            Facebook
          </mj-social-element>
          <mj-social-element name="google" href="https://mjml.io/">
            Google
          </mj-social-element>
          <mj-social-element  name="instagram" href="https://mjml.io/">
            Instagram
          </mj-social-element>
        </mj-social>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```