### PR TITLE
fix #757 add lang attribute

### DIFF
--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -17,11 +17,14 @@ export default function skeleton(options) {
     style,
     forceOWADesktop,
     inlineStyle,
+    lang,
   } = options
+
+  const langAttribute = lang ? `lang="${lang}" ` : ''
 
   return `
     <!doctype html>
-    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+    <html ${langAttribute}xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
       <head>
         <title>
           ${title}

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -74,6 +74,7 @@ export default function mjml2html(mjml, options = {}) {
     style: [],
     title: '',
     forceOWADesktop: get(mjml, 'attributes.owa', 'mobile') === 'desktop',
+    lang: get(mjml, 'attributes.lang'),
   }
 
   const validatorOptions = {


### PR DESCRIPTION
Need doc update.
I didn't see reference to the "owa" attribute either in the doc, where should we put those ?