### PR TITLE
mjml-column: Background property on table is invalid, should have been css style or bgcolor instead

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -191,7 +191,7 @@ export default class MjColumn extends BodyComponent {
     return `
       <table
         ${this.htmlAttributes({
-          background: this.getAttribute('background-color'),
+          bgcolor: this.getAttribute('background-color'), // TODO: move this attribute into css style as recommended in https://developer.mozilla.org/cs/docs/Web/HTML/Element/table
           border: '0',
           cellpadding: '0',
           cellspacing: '0',

--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -251,7 +251,7 @@ export default class MjSection extends BodyComponent {
         <table
           ${this.htmlAttributes({
             align: 'center',
-            background: this.isFullWidth()
+            background: this.isFullWidth() // TODO: <table background="..." is not valid and we need to put image bacground there through style, see https://developer.mozilla.org/cs/docs/Web/HTML/Element/table
               ? null
               : this.getAttribute('background-url'),
             border: '0',
@@ -302,7 +302,7 @@ export default class MjSection extends BodyComponent {
         ${this.htmlAttributes({
           align: 'center',
           class: this.getAttribute('css-class'),
-          background: this.getAttribute('background-url'),
+          background: this.getAttribute('background-url'), // TODO: <table background="..." is not valid and we need to put image bacground there through style, see https://developer.mozilla.org/cs/docs/Web/HTML/Element/table
           border: '0',
           cellpadding: '0',
           cellspacing: '0',


### PR DESCRIPTION
Partially fixes #1174.

As I don't know the codebase, I did what I could - replacing non-existent `<table>`'s `background` property with deprecated `bgcolor` property in a single place where I know a color will be used - `mjml-column`.

In two other places in `mjml-section` I at least added TODO.

Ideal way of solving this would be to move the background color/image definition into inline css styles in all three places.
