### PR TITLE
#200 - Ability to add custom properties

### DIFF
--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -14,6 +14,7 @@ export default class MjButton extends BodyComponent {
     border: 'string',
     color: 'color',
     'container-background-color': 'color',
+    data: 'object',
     'font-family': 'string',
     'font-size': 'unit(px)',
     'font-style': 'string',
@@ -42,6 +43,7 @@ export default class MjButton extends BodyComponent {
     border: 'none',
     'border-radius': '3px',
     color: '#ffffff',
+    data: {},
     'font-family': 'Ubuntu, Helvetica, Arial, sans-serif',
     'font-size': '13px',
     'font-weight': 'normal',
@@ -91,6 +93,7 @@ export default class MjButton extends BodyComponent {
 
   render() {
     const tag = this.getAttribute('href') ? 'a' : 'p'
+    const data = JSON.parse(this.getAttribute('data'))
 
     return `
       <table
@@ -102,6 +105,7 @@ export default class MjButton extends BodyComponent {
           role: 'presentation',
           style: 'table',
         })}
+        ${this.htmlAttributes(data)}
       >
         <tr>
           <td

--- a/packages/mjml-validator/src/types/index.js
+++ b/packages/mjml-validator/src/types/index.js
@@ -4,6 +4,7 @@ import Enum, { matcher as enumMatcher } from './enum'
 import Unit, { matcher as unitMatcher } from './unit'
 import NString, { matcher as stringMatcher } from './string'
 import NInteger, { matcher as intMatcher } from './integer'
+import NObject, { matcher as objectMatcher } from './object'
 
 export default {
   boolean: { matcher: booleanMatcher, typeConstructor: NBoolean },
@@ -12,4 +13,5 @@ export default {
   unit: { matcher: unitMatcher, typeConstructor: Unit },
   string: { matcher: stringMatcher, typeConstructor: NString },
   integer: { matcher: intMatcher, typeConstructor: NInteger },
+  object: { matcher: objectMatcher, typeConstructor: NObject },
 }

--- a/packages/mjml-validator/src/types/object.js
+++ b/packages/mjml-validator/src/types/object.js
@@ -1,0 +1,12 @@
+import Type from './type'
+
+export const matcher = /^object/gim
+
+export default params =>
+  class NObject extends Type {
+    constructor(value) {
+      super(value)
+
+      this.matchers = [/{.*}/]
+    }
+  }

--- a/packages/mjml-validator/src/types/object.js
+++ b/packages/mjml-validator/src/types/object.js
@@ -2,7 +2,7 @@ import Type from './type'
 
 export const matcher = /^object/gim
 
-export default params =>
+export default () =>
   class NObject extends Type {
     constructor(value) {
       super(value)

--- a/test.js
+++ b/test.js
@@ -2,6 +2,8 @@ require('babel-register')
 
 const mjml2html = require('./packages/mjml/src/index')
 
+const data = { hello: 'hi', 'how': 'are you' }
+
 const xml = `
 <mjml>
     <mj-head>
@@ -19,6 +21,9 @@ const xml = `
         <mj-wrapper>
             <mj-section>
                 <mj-column>
+                    <mj-button data='{ "hello": "world" }'>
+                      Hello
+                    </mj-button>
                     <mj-text>
                         lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem lorem
                     </mj-text>

--- a/type.js
+++ b/type.js
@@ -5,6 +5,7 @@ const colortype = types.initializeType('color')
 const booleantype = types.initializeType('boolean')
 const unittype = types.initializeType('unit(px,%){1,3}')
 const stringtype = types.initializeType('string')
+const objecttype = types.initializeType('object')
 
 console.log(stringtype)
 
@@ -24,5 +25,5 @@ const output = (t) => { console.log(`Type: ${t.constructor.name} — Value: ${t.
   new unittype('10px 10px'),
   new unittype('0'),
   new stringtype('hello world'),
+  new objecttype('{ "hello": "world" }'),
 ].map(output)
-


### PR DESCRIPTION
**WIP, don't merge**

I'm working on the #200 issue, opening this PR to open the discussion about the way to do that.

Personally I thought as @charlex, with that kind of potential solution:
```
<mj-text 
  color="#ffffff" 
  font-size="28" 
  align="center" 
  padding-top="40"
  custom-attrs={
    'mc:edit': 'foobar',
    hello: 'world',
    active: true,
    archived: false,
    'no-value-attr-1': null,
    'no-value-attr-2': undefined,
  }
>
```

So I add a new *object* type, you send an object and inside a string (JSON formatted), so something like that:

```
<mj-button data='{"foo": "bar"}'>
  Hello
</mj-button>
```
(for now, it's only working with button but it's really easy to set on other components)

Data props will be checked by a regex in data object (just like other props types: strings, enum, units...) and then, I parse the JSON into the render method to send it to htmlAttributes method. looks like:

![image](https://user-images.githubusercontent.com/14930937/42133195-00679426-7d26-11e8-92ac-7c3c6f3e13ee.png)

If anybody has another idea, perhaps cleaner, I would look 👍 