### PR TITLE
fix #1261 remove align on table on mj-button and mj-image

### DIFF
--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -95,7 +95,6 @@ export default class MjButton extends BodyComponent {
     return `
       <table
         ${this.htmlAttributes({
-          align: this.getAttribute('align'),
           border: '0',
           cellpadding: '0',
           cellspacing: '0',

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -141,7 +141,6 @@ export default class MjImage extends BodyComponent {
     return `
       <table
         ${this.htmlAttributes({
-          align: this.getAttribute('align'),
           border: '0',
           cellpadding: '0',
           cellspacing: '0',


### PR DESCRIPTION
align is already applied to the wrapping td by parent, and applying it to the table too breaks on outlook >= 2007 when align is right (center works fine)
removing it fixes that and doesn't seem to break on other clients