### PR TITLE
Improve documentation around validation levels when using CLI

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -57,6 +57,7 @@ argument | description | default value
 `mjml -w [input]` | Watches the changes made to [input] (file or folder) | NA
 `mjml [input] --config.beautify` | Beautifies the output (`true` or `false`) | true
 `mjml [input] --config.minify` | Minifies the output (`true` or `false`) | false
+`mjml [input] --config.validationLevel` | [Validation level](https://github.com/mjmlio/mjml/tree/master/packages/mjml-validator#validating-mjml): 'strict', 'soft' or 'skip' | 'soft'
 
 ## Inside Node.js
 

--- a/packages/mjml-validator/README.md
+++ b/packages/mjml-validator/README.md
@@ -10,19 +10,21 @@ By default, the level is set to `soft`.
 
 ## In CLI
 
-When using the `mjml` command line, you can add the option `-l` or `--level` with the validation level you want.
+When using the `mjml` command line, you can add the option `-c.validationLevel` or `--config.validationLevel` with the validation level you want.
 
-> Validates the file without rendering it
+> Set the validation level to `skip` (so that the file is not validated) and render the file
+
+```bash
+mjml --config.validationLevel=skip template.mjml
+```
+
+Alternatively, you can just validate file without rendering it by add ing the `--validate` option
 
 ```bash
 mjml --validate template.mjml
 ```
 
-> Sets the validation level to `skip` (so that the file is not validated) and renders the file
 
-```bash
-mjml -l skip -r template.mjml
-```
 
 ## In Javascript
 

--- a/packages/mjml-validator/README.md
+++ b/packages/mjml-validator/README.md
@@ -24,8 +24,6 @@ Alternatively, you can just validate file without rendering it by add ing the `-
 mjml --validate template.mjml
 ```
 
-
-
 ## In Javascript
 
 In Javascript, you can provide the level through the `options` parameters on `MJMLRenderer`. Ex: `new MJMLRenderer(inputMJML, { level: strict })`


### PR DESCRIPTION
The documentation for setting validation level when using the CLI mentioned a `-l` option to set the validation level. This option seems to be no longer supported, but setting `--config.validationLevel=$level` works. I added documentation for the `--config.validationLevel` option in both the [Usage](https://github.com/mjmlio/mjml/blob/master/doc/install.md#command-line-interface) section and the [Validations](https://github.com/mjmlio/mjml/blob/master/packages/mjml-validator/README.md#validating-mjml) section.