### PR TITLE
Update `ignoreInclude` flag to be `ignoreIncludes`

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -67,7 +67,7 @@ class Component {
       mjml = MJMLParser(mjml, {
         ...options,
         components,
-        ignoreInclude: true,
+        ignoreIncludes: true,
       })
     }
 


### PR DESCRIPTION
When creating a new component, the MJMLParser does not ignore includes due to the flag being named incorrectly.