### PR TITLE
Remove illegal text-mode attribute in documentation

### DIFF
--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -90,7 +90,6 @@ icon-height                 | percent/px  | icon height, overrides icon-size | i
 line-height                 | percent/px  | space between lines           | 22px
 mode                        | string      | vertical/horizontal           | horizontal
 text-decoration             | string      | underline/overline/none       | none
-text-mode                   | string      | display social network name   | true
 align                       | string      | left/right/center             | center
 color                       | color       | text color                    | #333333
 name                        | string      | `facebook google instagram pinterest linkedin twitter` | N/A


### PR DESCRIPTION
`text-mode` [is unused when rendering `<mj-social-element>`](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/src/SocialElement.js#L194-L207), and it is deemed illegal during [validation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/src/SocialElement.js#L46-L68).