### PR TITLE
Fix mj-spacer default height

### DIFF
--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -20,7 +20,9 @@ export default class MjSpacer extends BodyComponent {
     height: 'unit(px,%)',
   }
 
-  static defaultAttributes = {}
+  static defaultAttributes = {
+    height: '20px',
+  }
 
   getStyles() {
     return {


### PR DESCRIPTION
Docs say `mj-spacer` should have a default height of 20px but no default is set. 

https://mjml.io/documentation/#mjml-spacer