### PR TITLE
fix #1357 hero children width shouldnt depend on siblings

### DIFF
--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -14,13 +14,11 @@ Fixed height
     <mj-hero
       mode="fixed-height"
       height="469px"
-      width="100%"
       background-width="600px"
       background-height="469px"
       background-url="https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg"
       background-color="#2a3448"
       padding="100px 0px">
-      <!-- To add content like mj-image, mj-text, mj-button ... use the mj-hero-content component -->
       <mj-text
         padding="20px"
         color="#ffffff"

--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -144,6 +144,7 @@ export default class MjHero extends BodyComponent {
         'background-color': this.getAttribute('inner-background-color'),
         float: this.getAttribute('align'),
         margin: '0px auto',
+        width: this.getAttribute('width'),
       },
     }
   }

--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -48,13 +48,12 @@ export default class MjHero extends BodyComponent {
   getChildContext() {
     // Refactor -- removePaddingFor(width, ['padding', 'inner-padding'])
     const { containerWidth } = this.context
-    const { sibling } = this.props
     const paddingSize =
       this.getShorthandAttrValue('padding', 'left') +
       this.getShorthandAttrValue('padding', 'right')
 
     let currentContainerWidth =
-      this.getAttribute('width') || `${parseFloat(containerWidth) / sibling}px`
+      this.getAttribute('width') || `${parseFloat(containerWidth)}px`
 
     const { unit, parsedWidth } = widthParser(currentContainerWidth, {
       parseFloatToInt: false,

--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -52,8 +52,7 @@ export default class MjHero extends BodyComponent {
       this.getShorthandAttrValue('padding', 'left') +
       this.getShorthandAttrValue('padding', 'right')
 
-    let currentContainerWidth =
-      this.getAttribute('width') || `${parseFloat(containerWidth)}px`
+    let currentContainerWidth = `${parseFloat(containerWidth)}px`
 
     const { unit, parsedWidth } = widthParser(currentContainerWidth, {
       parseFloatToInt: false,
@@ -145,7 +144,6 @@ export default class MjHero extends BodyComponent {
         'background-color': this.getAttribute('inner-background-color'),
         float: this.getAttribute('align'),
         margin: '0px auto',
-        width: this.getAttribute('width'),
       },
     }
   }


### PR DESCRIPTION
the `siblings` prop is no longer used anywhere since column now use `nonRawSiblings`, should we remove it ?