### PR TITLE
Allow config.fonts to be set from CLI

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -90,7 +90,15 @@ export default async () => {
     .help()
     .version(`mjml-core: ${coreVersion}\nmjml-cli: ${cliVersion}`).argv
 
-  const config = Object.assign(DEFAULT_OPTIONS, argv.c)
+  let fonts
+
+  try {
+    fonts = argv.c && argv.c.fonts && JSON.parse(argv.c.fonts)
+  } catch (e) {
+    error(`Failed to decode JSON for config.fonts argument`)
+  }
+
+  const config = Object.assign(DEFAULT_OPTIONS, argv.c, fonts && {fonts})
   const inputArgs = pickArgs(['r', 'w', 'i', '_', 'm', 'v'])(argv)
   const outputArgs = pickArgs(['o', 's'])(argv)
 


### PR DESCRIPTION
MJML detects font usage in `font-family` attributes and, for a predefined [list of fonts](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L45), adds the required `<link>` and `@import` rules. Unfortunately, using 'Roboto Condensed' results in MJML injecting links to plain old Roboto in addition to the `mj-font` I defined.

This PR allows for the list of automatically injected fonts to be set via the CLI.

Tested locally using this command:

`./packages/mjml/bin/mjml test.mjml --config.fonts '{}'`

Input:

```html
<mjml>
    <mj-head>
        <mj-font name="Roboto Condensed" href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400" />
    </mj-head>
    <mj-body>
        <mj-text font-family="Roboto Condensed">
            <p>Hello, MJML!</p>
        </mj-text>
    </mj-body>
</mjml>
```

Output before change (`./packages/mjml/bin/mjml test.mjml`):

```html
<!-- FILE: test.mjml -->
<!doctype html>
<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">

<head>

  <!-- ...rest of MJML head output... -->

  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
  <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400" rel="stylesheet" type="text/css">
  <style type="text/css">
    @import url(https://fonts.googleapis.com/css?family=Roboto:300,400,500,700);
    @import url(https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400);
  </style>
  <!--<![endif]-->
  <style type="text/css">
  </style>
</head>

<body>
  <div style="">
    <div style="font-family:Roboto Condensed;font-size:13px;line-height:1;text-align:left;color:#000000;">
      <p>Hello, MJML!</p>
    </div>
  </div>
</body>

</html>
```

Output after change (`./packages/mjml/bin/mjml test.mjml --config.fonts '{}'`):

```html
<!-- FILE: test.mjml -->
<!doctype html>
<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">

<head>

  <!-- ...rest of MJML head output... -->
  
  <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400" rel="stylesheet" type="text/css">
  <style type="text/css">
    @import url(https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400);
  </style>
  <!--<![endif]-->
  <style type="text/css">
  </style>
</head>

<body>
  <div style="">
    <div style="font-family:Roboto Condensed;font-size:13px;line-height:1;text-align:left;color:#000000;">
      <p>Hello, MJML!</p>
    </div>
  </div>
</body>

</html>

```