### PR TITLE
Add css-class to body components documentation

### DIFF
--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -64,6 +64,7 @@ attribute                   | unit               | description                  
 ----------------------------|--------------------|--------------------------------------------------------------------------------------------------|-----------------
 align                       | string             | align content left/center/right                                                                  | center
 base url                    | string             | base url for children components                                                                 | n/a
+css-class                   | string             | class name, added to the root HTML element created                                               | n/a
 hamburger                   | string             | activate the hamburger navigation on mobile if the value is hamburger                            | n/a
 ico-align                   | string             | hamburger icon alignment, left/center/right (hamburger mode required)                            | center
 ico-close                   | ASCII code decimal | char code for a custom close icon (hamburger mode required)                                      | 8855
@@ -92,20 +93,21 @@ This component should be used to display an individual link in the navbar.
 
 attribute        | unit          | description                           | default value
 -----------------|---------------|---------------------------------------|------------------------------
-color            | color         | text color                            | #000000
-font-family      | string        | font                                  | Ubuntu, Helvetica, Arial, sans-serif
-font-size        | px            | text size                             | 13px
-font-style       | string        | normal/italic/oblique                 | n/a
-font-weight      | number        | text thickness                        | n/a
-href             | string        | link to redirect to on click          | n/a
-line-height      | px            | space between the lines               | 22px
-padding          | px            | supports up to 4 parameters           | 10px 25px
-padding-bottom   | px            | bottom offset                         | n/a
-padding-left     | px            | left offset                           | n/a
-padding-right    | px            | right offset                          | n/a
-padding-top      | px            | top offset                            | n/a
-rel              | string        | specify the rel attribute             | n/a
-target           | string        | link target on click                  | n/a
-text-decoration  | string        | underline/overline/none               | n/a
-text-transform   | string        | capitalize/uppercase/lowercase/none   | uppercase
+color            | color         | text color                                         | #000000
+css-class        | string        | class name, added to the root HTML element created | n/a
+font-family      | string        | font                                               | Ubuntu, Helvetica, Arial, sans-serif
+font-size        | px            | text size                                          | 13px
+font-style       | string        | normal/italic/oblique                              | n/a
+font-weight      | number        | text thickness                                     | n/a
+href             | string        | link to redirect to on click                       | n/a
+line-height      | px            | space between the lines                            | 22px
+padding          | px            | supports up to 4 parameters                        | 10px 25px
+padding-bottom   | px            | bottom offset                                      | n/a
+padding-left     | px            | left offset                                        | n/a
+padding-right    | px            | right offset                                       | n/a
+padding-top      | px            | top offset                                         | n/a
+rel              | string        | specify the rel attribute                          | n/a
+target           | string        | link target on click                               | n/a
+text-decoration  | string        | underline/overline/none                            | n/a
+text-transform   | string        | capitalize/uppercase/lowercase/none                | uppercase
 

--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -40,6 +40,7 @@ attribute                   | unit        | description                   | defa
 align                       | string      | left/right/center             | center
 border-radius               | px          | border radius                 | 3px
 color                       | color       | text color                    | #333333
+css-class                   | string      | class name, added to the root HTML element created | n/a
 container-background-color  | color       | inner element background color                     | n/a
 font-family                 | string      | font name                     | Ubuntu, Helvetica, Arial, sans-serif
 font-size                   | px/em       | font size                     | 13px
@@ -72,6 +73,7 @@ alt                         | string      | image alt attribute           | none
 background-color            | color       | icon color                    | Each social `name` has its own default
 border-radius               | px          | border radius                 | 3px
 color                       | color       | text color                    | #333333
+css-class                   | string      | class name, added to the root HTML element created | n/a
 font-family                 | string      | font name                     | Ubuntu, Helvetica, Arial, sans-serif
 font-size                   | px/em       | font size                     | 13px
 font-style                  | string      | font style                    | normal

--- a/packages/mjml-table/README.md
+++ b/packages/mjml-table/README.md
@@ -42,6 +42,7 @@ cellpadding                 | pixels                      | space between cells 
 cellspacing                 | pixels                      | space between cell and border  | n/a
 color                       | color                       | text header & footer color     | #000000
 container-background-color  | color                       | inner element background color | n/a
+css-class                   | string                      | class name, added to the root HTML element created | n/a
 font-family                 | string                      | font name                      | Ubuntu, Helvetica, Arial, sans-serif
 font-size                   | px                          | font size                      | 13px
 font-style                  | string                      | font style                     | n/a


### PR DESCRIPTION
The `css-table` attribute is accepted by all body components.
