### PR TITLE
remove whitespace within div of mjml-text

### DIFF
--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -60,9 +60,7 @@ export default class MjText extends BodyComponent {
         ${this.htmlAttributes({
           style: 'text',
         })}
-      >
-        ${this.getContent()}
-      </div>
+      >${this.getContent()}</div>
     `
   }
 


### PR DESCRIPTION
The indentation used for code legibility within the template literal/string of mjml-text's `renderContent()` (whitespace between the `<div>` and the actual content) can unintentionally be rendered in the generated HTML.

This can happen if the content within the `<mj-text>` is (a) not wrapped by another tag and (b) styled to preserve whitespace/line breaks, via something like this:

```xml
<mjml>
  <mj-head>
    <mj-style>.activity-body { white-space: pre-wrap; }</mj-style>
  </mj-head>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-text css-class="activity-body">Hello world!</mj-text>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

To fix this, I have removed the whitespace between the `<div>` and the content within the template literal/string.