### PR TITLE
fix #1585 fix handling of mj-head and includedIn in mj-includes

### DIFF
--- a/packages/mjml-parser-xml/src/index.js
+++ b/packages/mjml-parser-xml/src/index.js
@@ -56,6 +56,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
 
   const handleInclude = (file, line) => {
     const partialPath = path.resolve(cwd, file)
+    const curBeforeInclude = cur
 
     if (find(cur.includedIn, { file: partialPath }))
       throw new Error(`Circular inclusion detected on file : ${partialPath}`)
@@ -113,10 +114,8 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
     if (body) {
       const boundChildren = bindToTree(body.children)
       cur.children = [...cur.children, ...boundChildren]
-
-      cur = boundChildren[boundChildren.length - 1]
     }
-
+    
     if (head) {
       let curHead = findTag('mj-head', mjml)
 
@@ -127,6 +126,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
           parent: mjml,
           tagName: 'mj-head',
           children: [],
+          includedIn: [],
         })
 
         curHead = findTag('mj-head', mjml)
@@ -134,9 +134,10 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
 
       const boundChildren = bindToTree(head.children, curHead)
       curHead.children = [...curHead.children, ...boundChildren]
-
-      cur = boundChildren[boundChildren.length - 1]
     }
+    
+    // must restore cur to the cur before include started
+    cur = curBeforeInclude
   }
 
   const parser = new htmlparser.Parser(
@@ -210,8 +211,10 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
         if (inInclude) {
           inInclude = false
         }
-
-        cur = (cur && cur.parent) || null
+        
+        // for includes, setting cur is handled in handleInclude because when there is
+        // only mj-head in include it doesn't create any elements, so setting back to parent is wrong
+        if (name !== 'mj-include') cur = (cur && cur.parent) || null
       },
       ontext: text => {
         if (inEndingTag > 0) return
@@ -228,6 +231,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
             line: findLastIndex(lineIndexes, i => i <= parser.startIndex) + 1,
             tagName: 'mj-raw',
             content: `<!-- ${data.trim()} -->`,
+            includedIn,
           })
         }
       },


### PR DESCRIPTION
bug was caused by the fact that cur wasn't correctly set after handling a mj-head in a mj-include
also fixes a bug related to includedIn when no mj-head in parent mjml file, and then mj-heads in mj-includes