### PR TITLE
fix #1607 cur when failed include

### DIFF
--- a/packages/mjml-parser-xml/src/index.js
+++ b/packages/mjml-parser-xml/src/index.js
@@ -76,7 +76,6 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
         children: [],
       }
       cur.children.push(newNode)
-      cur = newNode
 
       return
     }


### PR DESCRIPTION
handling of `cur` in mj-includes have been changed in a previous commit to fix includes in mj-head, so it needed the same change when handling a failed include