### PR TITLE
Allow social elements without links

### DIFF
--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -229,11 +229,13 @@ export default class MjSocialElement extends BodyComponent {
           >
             <tr>
               <td ${this.htmlAttributes({ style: 'icon' })}>
-                <a ${this.htmlAttributes({
-                  href,
-                  rel: this.getAttribute('rel'),
-                  target: this.getAttribute('target'),
-                })}>
+                ${this.getAttribute('href') != '' ?
+                  `<a ${this.htmlAttributes({
+                    href,
+                    rel: this.getAttribute('rel'),
+                    target: this.getAttribute('target'),
+                  })}>` : ''
+                }
                     <img
                       ${this.htmlAttributes({
                         alt: this.getAttribute('alt'),
@@ -244,7 +246,9 @@ export default class MjSocialElement extends BodyComponent {
                         width: parseInt(iconSize, 10),
                       })}
                     />
-                  </a>
+                  ${this.getAttribute('href') != '' ?
+                    `</a>` : ''
+                  }
                 </td>
               </tr>
           </table>
@@ -252,15 +256,23 @@ export default class MjSocialElement extends BodyComponent {
         ${this.getContent()
           ? `
           <td ${this.htmlAttributes({ style: 'tdText' })}>
-            <a
-              ${this.htmlAttributes({
-                href,
-                style: 'text',
-                rel: this.getAttribute('rel'),
-                target: this.getAttribute('target'),
-              })}>
+            ${this.getAttribute('href') != '' ?
+              `<a
+                ${this.htmlAttributes({
+                  href,
+                  style: 'text',
+                  rel: this.getAttribute('rel'),
+                  target: this.getAttribute('target'),
+                })}>`
+              :  `<span
+                    ${this.htmlAttributes({
+                      style: 'text',
+                    })}>`
+            }
               ${this.getContent()}
-            </a>
+            ${this.getAttribute('href') != '' ?
+              `</a>` : '</span>'
+            }
           </td>
           `
           : ''}


### PR DESCRIPTION
Opening this as a workaround for #579. Social elements work as a perfect media object (fixed width element on the left + text filling the remaining width).

It will be possible to rewrite this into a completely new component but this is out of my abilities at the moment. I know it isn't an ideal solution so feel free to close it if this is something that should not be merged – however I think it doesn't break anything and actually works just fine.

This is what I want to achieve:

![image](https://user-images.githubusercontent.com/11633481/62541761-b8e39200-b85a-11e9-8f3e-d179e470001a.png)

If there is any cleaner workaround just tell me :)