### PR TITLE
Update to latest Yargs to resolve vulnerable transient dependencies

### DIFF
--- a/packages/mjml-cli/package.json
+++ b/packages/mjml-cli/package.json
@@ -28,7 +28,7 @@
     "mjml-migrate": "4.4.1",
     "mjml-parser-xml": "4.4.1",
     "mjml-validator": "4.4.1",
-    "yargs": "^8.0.2"
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "chai": "^4.1.1",


### PR DESCRIPTION
GitHub reports a CVE in the following dependency chain:

mjml@4.4.1 > mjml-cli@4.4.1 > yargs@^8 > os-locale@^2 > mem@^1

All of these are patch pinned, and mem@1 is not patched, however,
both yargs@8 and mem@1 are WAY behind: yargs@13 and mem@4 are available.
I suggest mjml-cli updates to yargs@^13 to resolve this vulnerability
for everyone depending on mjml.