### PR TITLE
Support custom attributes for mj-image link

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -127,6 +127,7 @@ export class BodyComponent extends Component {
   }
 
   htmlAttributes(attributes) {
+    const self = this
     const specialAttributes = {
       style: v => this.styles(v),
       default: identity,
@@ -138,35 +139,21 @@ export class BodyComponent extends Component {
         const value = (specialAttributes[name] || specialAttributes.default)(v)
 
         if (!isNil(value)) {
-          return `${output} ${name}="${value}"`
+          let pairs
+          if(self.isCustomAttr({name})){
+            pairs = self.getCustomAttrVals({name, value})
+          }
+          else{
+            pairs = `${name}="${value}"`
+          }
+
+          return `${output} ${pairs}`
         }
 
         return output
       },
       '',
     )
-  }
-
-  applyCustomAttrs({htmlAttrs, attrName}) {
-    try{
-      const customLinkAttrsStr = this.getAttribute(attrName)
-      if(customLinkAttrsStr){
-        const attrsArr = customLinkAttrsStr.split(';')
-        for(const attrItem of attrsArr){
-          if(attrItem){
-            const pair = attrItem.split(':')
-            const key = pair[0].trim()
-            const val = pair[1].trim()
-            if(key){
-              htmlAttrs[key] = val
-            }
-          }
-        }       
-      }
-    }
-    catch(err){
-      console.log(`Attribute value for attribute ${attrName} is illegal`)
-    }
   }
 
   styles(styles) {
@@ -190,6 +177,28 @@ export class BodyComponent extends Component {
       },
       '',
     )
+  }
+
+  isCustomAttr({name}){
+    const cusAttrPrefix = 'custom-attr-'
+    return (name.startsWith(cusAttrPrefix))
+  }
+
+  getCustomAttrVals({name, value}){
+    let pairStr = ''
+    const attrsArr = value.split(';')
+    for(let i = 0; i < attrsArr.length; i++){
+      const attrItem = attrsArr[i]
+      if(attrItem){
+        const pair = attrItem.split(':')
+        const key = pair[0].trim()
+        const val = pair[1].trim()
+        if(key){
+          pairStr += `${key}="${val}" `
+        }
+      }
+    }
+    return pairStr
   }
 
   renderChildren(childrens, options = {}) {

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -152,11 +152,11 @@ export class BodyComponent extends Component {
       const customLinkAttrsStr = this.getAttribute(attrName)
       if(customLinkAttrsStr){
         const attrsArr = customLinkAttrsStr.split(';')
-        for(let attrItem of attrsArr){
+        for(const attrItem of attrsArr){
           if(attrItem){
-            let pair = attrItem.split(':')
-            let key = pair[0].trim()
-            let val = pair[1].trim()
+            const pair = attrItem.split(':')
+            const key = pair[0].trim()
+            const val = pair[1].trim()
             if(key){
               htmlAttrs[key] = val
             }

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -127,7 +127,6 @@ export class BodyComponent extends Component {
   }
 
   htmlAttributes(attributes) {
-    const self = this
     const specialAttributes = {
       style: v => this.styles(v),
       default: identity,
@@ -140,8 +139,8 @@ export class BodyComponent extends Component {
 
         if (!isNil(value)) {
           let pairs
-          if(self.isCustomAttr({name})){
-            pairs = self.getCustomAttrVals({name, value})
+          if(this.isCustomAttr({name})){
+            pairs = this.getCustomAttrStr({value})
           }
           else{
             pairs = `${name}="${value}"`
@@ -184,21 +183,33 @@ export class BodyComponent extends Component {
     return (name.startsWith(cusAttrPrefix))
   }
 
-  getCustomAttrVals({name, value}){
-    let pairStr = ''
+  getCustomAttrStr({value}){
     const attrsArr = value.split(';')
-    for(let i = 0; i < attrsArr.length; i++){
-      const attrItem = attrsArr[i]
-      if(attrItem){
-        const pair = attrItem.split(':')
-        const key = pair[0].trim()
-        const val = pair[1].trim()
-        if(key){
-          pairStr += `${key}="${val}" `
+    return reduce(
+      attrsArr,
+      (output, attrItem) => {
+        if(attrItem){
+          const pair = attrItem.split(':')
+          const key = pair[0]
+          const val = pair[1]
+          if(isNil(key) || !key.trim()){
+            return output
+          }
+          else{
+            if(isNil(val)){
+              return `${output} ${key}`
+            }
+            else{
+              return `${output} ${key.trim()}="${val.trim()}"`
+            }
+          }
         }
-      }
-    }
-    return pairStr
+        else{
+          return output
+        }
+      },
+      '',
+    )
   }
 
   renderChildren(childrens, options = {}) {

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -147,6 +147,28 @@ export class BodyComponent extends Component {
     )
   }
 
+  applyCustomAttrs({htmlAttrs, attrName}) {
+    try{
+      const customLinkAttrsStr = this.getAttribute(attrName)
+      if(customLinkAttrsStr){
+        const attrsArr = customLinkAttrsStr.split(';')
+        for(let attrItem of attrsArr){
+          if(attrItem){
+            let pair = attrItem.split(':')
+            let key = pair[0].trim()
+            let val = pair[1].trim()
+            if(key){
+              htmlAttrs[key] = val
+            }
+          }
+        }       
+      }
+    }
+    catch(err){
+      console.log(`Attribute value for attribute ${attrName} is illegal`)
+    }
+  }
+
   styles(styles) {
     let stylesObject
 

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -44,5 +44,5 @@ srcset                        | url & width   | enables to set a different image
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
 width                         | px            | image width                    | 100%
-custom-attr-a                 | string        | specify attributes to attach to the anchor tag, use key:value pairs, example: key1:val1;key2:val2; | n/a
-custom-attr-img               | string        | specify attributes to attach to the img tag, use key:value pairs, example: key1:val1;key2:val2; | n/a
+custom-attr-a                 | string        | specify attributes to attach to the anchor tag, use key:val pairs, example: key1:val1;key2:val2; | n/a
+custom-attr-img               | string        | specify attributes to attach to the img tag, use key:val pairs, example: key1:val1;key2:val2; | n/a

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -44,4 +44,4 @@ srcset                        | url & width   | enables to set a different image
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
 width                         | px            | image width                    | 100%
-
+custom-link-attrs             | string        | specify attributes to attach to the anchor tag, use key:value pairs and split by semicolum(;) if multiple attributes are provided; example: key1:val1;key2:val2; | n/a

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -44,4 +44,5 @@ srcset                        | url & width   | enables to set a different image
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
 width                         | px            | image width                    | 100%
-custom-link-attrs             | string        | specify attributes to attach to the anchor tag, use key:value pairs and split by semicolum(;) if multiple attributes are provided; example: key1:val1;key2:val2; | n/a
+custom-attr-a                 | string        | specify attributes to attach to the anchor tag, use key:value pairs, example: key1:val1;key2:val2; | n/a
+custom-attr-img               | string        | specify attributes to attach to the img tag, use key:value pairs, example: key1:val1;key2:val2; | n/a

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -111,7 +111,7 @@ export default class MjImage extends BodyComponent {
     `
 
     if (this.getAttribute('href')) {
-      let htmlAttrs = {   
+      const htmlAttrs = {   
         href: this.getAttribute('href'),
         target: this.getAttribute('target'),
         rel: this.getAttribute('rel'),

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -34,7 +34,8 @@ export default class MjImage extends BodyComponent {
     height: 'unit(px,auto)',
     'max-height': 'unit(px,%)',
     'font-size': 'unit(px)',
-    'custom-link-attrs': 'string',
+    'custom-attr-a': 'string',
+    'custom-attr-img': 'string',
   }
 
   static defaultAttributes = {
@@ -106,23 +107,21 @@ export default class MjImage extends BodyComponent {
           style: 'img',
           title: this.getAttribute('title'),
           width: this.getContentWidth(),
+          'custom-attr-img': this.getAttribute('custom-attr-img'),
         })}
       />
     `
 
     if (this.getAttribute('href')) {
-      const htmlAttrs = {   
-        href: this.getAttribute('href'),
-        target: this.getAttribute('target'),
-        rel: this.getAttribute('rel'),
-        name: this.getAttribute('name'),
-      }
-
-      this.applyCustomAttrs({htmlAttrs, attrName:'custom-link-attrs'})
-
       return `
         <a
-          ${this.htmlAttributes(htmlAttrs)}
+          ${this.htmlAttributes({
+            href: this.getAttribute('href'),
+            target: this.getAttribute('target'),
+            rel: this.getAttribute('rel'),
+            name: this.getAttribute('name'),
+            'custom-attr-a': this.getAttribute('custom-attr-a'),
+          })}
         >
           ${img}
         </a>

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -34,6 +34,7 @@ export default class MjImage extends BodyComponent {
     height: 'unit(px,auto)',
     'max-height': 'unit(px,%)',
     'font-size': 'unit(px)',
+    'custom-link-attrs': 'string',
   }
 
   static defaultAttributes = {
@@ -110,14 +111,18 @@ export default class MjImage extends BodyComponent {
     `
 
     if (this.getAttribute('href')) {
+      let htmlAttrs = {   
+        href: this.getAttribute('href'),
+        target: this.getAttribute('target'),
+        rel: this.getAttribute('rel'),
+        name: this.getAttribute('name'),
+      }
+
+      this.applyCustomAttrs({htmlAttrs, attrName:'custom-link-attrs'})
+
       return `
         <a
-          ${this.htmlAttributes({
-            href: this.getAttribute('href'),
-            target: this.getAttribute('target'),
-            rel: this.getAttribute('rel'),
-            name: this.getAttribute('name'),
-          })}
+          ${this.htmlAttributes(htmlAttrs)}
         >
           ${img}
         </a>


### PR DESCRIPTION
Story: some third party email delivery service (such as Campaign Monitor) can modify links to support their own link tracking, certain behavior can be controlled by supply custom attributes to the anchor tag.
Solution: this commit introduces new attribute to mj-image, here is how to use it <mj-image custom-link-attrs="key1:val1" />, it will add key="val1" to the a tag.