### PR TITLE
fix auto generated classes conflicts

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -156,15 +156,16 @@ export default class MjColumn extends BodyComponent {
     let className = ''
 
     const { parsedWidth, unit } = this.getParsedWidth()
-
+    const formattedClassNb = parsedWidth.toString().replace('.', '-')
+    
     switch (unit) {
       case '%':
-        className = `mj-column-per-${parseInt(parsedWidth, 10)}`
+          className = `mj-column-per-${formattedClassNb}`
         break
 
       case 'px':
       default:
-        className = `mj-column-px-${parseInt(parsedWidth, 10)}`
+        className = `mj-column-px-${formattedClassNb}`
         break
     }
 


### PR DESCRIPTION
When a column had a 33% width, and another section had an auto 33.3333% width, they had the same class name, thus one of them had a wrong width