### PR TITLE
Fix invalid font-size value on p tag when compiled to html

### DIFF
--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -31,7 +31,7 @@ export default class MjDivider extends BodyComponent {
       'border-top': ['style', 'width', 'color']
         .map(attr => this.getAttribute(`border-${attr}`))
         .join(' '),
-      'font-size': 1,
+      'font-size': '1px',
       margin: '0px auto',
       width: this.getAttribute('width'),
     }


### PR DESCRIPTION
When using mjml-divider and compiling to html afterwards, there is a `p` tag that has `font-size:1;` This causes a warning message when using Premailer for sending out emails (logged by cssutils)