### PR TITLE
Remove redundant padding from mjml-table docs

### DIFF
--- a/packages/mjml-table/README.md
+++ b/packages/mjml-table/README.md
@@ -8,7 +8,7 @@ This tag allows you to display table and filled it with data. It only accepts pl
     <mj-section>
       <mj-column>
         <mj-table>
-          <tr style="border-bottom:1px solid #ecedee;text-align:left;padding:15px 0;">
+          <tr style="border-bottom:1px solid #ecedee;text-align:left;">
             <th style="padding: 0 15px 0 0;">Year</th>
             <th style="padding: 0 15px;">Language</th>
             <th style="padding: 0 0 0 15px;">Inspired from</th>


### PR DESCRIPTION
[The docs of mjml-table](https://mjml.io/documentation/#mjml-table) has `style="border-bottom:1px solid #ecedee;text-align:left;padding:15px 0;` as the style set on the `<tr>` element. Padding cannot be ([famously](https://stackoverflow.com/questions/3656615/padding-a-table-row)) be applied to `table-row` elements. 

  **Reproduction Steps:**

  1. Go to the sample https://mjml.io/try-it-live/r1ihgX9uB
  2. Set the padding of the `<tr>` element to 100px

  **Expected behavior:**

  Padding increases

  **Observed behavior:**

  Padding doesn't increase

  **MJML version:**

  v4.5.1

  **Email clients the bug is seen on:**

  All