### PR TITLE
Set bgcolor on mj-group table

### DIFF
--- a/packages/mjml-group/src/index.js
+++ b/packages/mjml-group/src/index.js
@@ -158,7 +158,18 @@ export default class MjGroup extends BodyComponent {
         })}
       >
         <!--[if mso | IE]>
-        <table  role="presentation" border="0" cellpadding="0" cellspacing="0">
+        <table
+          ${this.htmlAttributes({
+            bgcolor:
+                this.getAttribute('background-color') === 'none'
+                  ? undefined
+                  : this.getAttribute('background-color'),
+            border: '0',
+            cellpadding: '0',
+            cellspacing: '0',
+            role: 'presentation',
+          })}
+        >
           <tr>
         <![endif]-->
           ${this.renderChildren(children, {


### PR DESCRIPTION
This is to fix outlook 2016 bug. I have no idea why but it just ignore background-color at top div.