### PR TITLE
mj-include not including files without .mjml in the config string

### DIFF
--- a/doc/components_2.md
+++ b/doc/components_2.md
@@ -19,7 +19,7 @@ tags to make it easier to preview outside the main template
 <!-- main.mjml -->
 <mjml>
   <mj-body>
-    <mj-include path="./header" /> <!-- or 'header.mjml' -->
+    <mj-include path="./header.mjml" />
   </mj-body>
 </mjml>
 ```


### PR DESCRIPTION
Fixes mjml/mjml#1763