### PR TITLE
[add] usemap attribute to image tag

### DIFF
--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -43,5 +43,6 @@ src                           | url           | image source                   |
 srcset                        | url & width   | enables to set a different image source based on the viewport | n/a
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
+usemap                        | string        | reference to image map, be careful, it isn't supported everywhere         | n/a
 width                         | px            | image width                    | 100%
 

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -34,6 +34,7 @@ export default class MjImage extends BodyComponent {
     height: 'unit(px,auto)',
     'max-height': 'unit(px,%)',
     'font-size': 'unit(px)',
+    usemap: 'string'
   }
 
   static defaultAttributes = {
@@ -105,6 +106,7 @@ export default class MjImage extends BodyComponent {
           style: 'img',
           title: this.getAttribute('title'),
           width: this.getContentWidth(),
+          usemap: this.getAttribute('usemap')
         })}
       />
     `

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -34,7 +34,7 @@ export default class MjImage extends BodyComponent {
     height: 'unit(px,auto)',
     'max-height': 'unit(px,%)',
     'font-size': 'unit(px)',
-    usemap: 'string'
+    usemap: 'string',
   }
 
   static defaultAttributes = {
@@ -106,7 +106,7 @@ export default class MjImage extends BodyComponent {
           style: 'img',
           title: this.getAttribute('title'),
           width: this.getContentWidth(),
-          usemap: this.getAttribute('usemap')
+          usemap: this.getAttribute('usemap'),
         })}
       />
     `


### PR DESCRIPTION
Added [usemap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map) attribute to image tag.
It can be used with `map` tag inside of the `mj-raw` component.