### PR TITLE
give correct options to watchFiles

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -168,7 +168,7 @@ export default async () => {
       break
     }
     case 'w':
-      watchFiles(inputFiles, argv)
+      watchFiles(inputFiles, { ...argv, config })
       KEEP_OPEN = true
       break
     case 'i':


### PR DESCRIPTION
fix #1812 
raw options were given to watchFiles, thus some options were unparsed Json string instead of object