### PR TITLE
Fix_1819; remove closing tags for HTML <img> tags; documentation only

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you're looking for MJML 3.3.X check [this branch](https://github.com/mjmlio/m
     <img src="https://travis-ci.org/mjmlio/mjml.svg?branch=master" alt="travis">
   </a>
   <a href="https://www.codacy.com/app/gbadi/mjml">
-    <img src="https://api.codacy.com/project/badge/grade/575339cb861f4ff4b0dbb3f9e1759c35"/>
+    <img src="https://api.codacy.com/project/badge/grade/575339cb861f4ff4b0dbb3f9e1759c35">
   </a>
 </p>
 

--- a/doc/basic.md
+++ b/doc/basic.md
@@ -10,7 +10,9 @@ Here is the final render we want to end with:
 </p>
 
 <p align="center">
-  <a href="/try-it-live/templates/basic"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
+  <a href="/try-it-live/templates/basic">
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
+  </a>
 </p>
 
 Looks cool, right?

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -43,5 +43,8 @@ MJML has been designed with responsiveness in mind. The abstraction it offers gu
   <br />
   <br />
   <br />
-  <a href="/try-it-live/intro"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
+  <a href="/try-it-live/intro">
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" 
+        alt="try it live">
+  </a>
 </p>

--- a/doc/install.md
+++ b/doc/install.md
@@ -25,7 +25,10 @@ You can also run `yarn build:watch` to rebuild the package as you code.
 Don't want to install anything? Use the free online editor!
 
 <p align="center">
-  <a href="http://mjml.io/try-it-live" target="_blank"><img src="https://cloud.githubusercontent.com/assets/6558790/12195421/58a40618-b5f7-11e5-9ed3-80463874ab14.png" alt="try it live" width="75%"></a>
+  <a href="http://mjml.io/try-it-live" target="_blank">
+    <img src="https://cloud.githubusercontent.com/assets/6558790/12195421/58a40618-b5f7-11e5-9ed3-80463874ab14.png"
+        alt="try it live" width="75%">
+  </a>
 </p>
 <br>
 

--- a/doc/mjml-chart.md
+++ b/doc/mjml-chart.md
@@ -3,7 +3,7 @@
 Thanks to [image-charts](https://image-charts.com/) for their contribution with this component. It's available on [Github](https://github.com/image-charts/mjml-charts) and [NPM](https://www.npmjs.com/package/mjml-chart).
 
 <p align="center">
-  <img src="https://puu.sh/tjIVp/cd01defdac.png" alt="mjml-charts" />
+  <img src="https://puu.sh/tjIVp/cd01defdac.png" alt="mjml-charts">
 </p>
 
 Displays charts as images in your email.

--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -1,7 +1,7 @@
 ## mjml-accordion
 
 <p align="center">
-  <img src="http://i.imgur.com/C4S9MVc.gif" alt="accordion" />
+  <img src="http://i.imgur.com/C4S9MVc.gif" alt="accordion">
 </p>
 
 `mjml-accordion` is an interactive MJML component to stack content in tabs, so the information is collapsed and only the titles are visible. Readers can interact by clicking on the tabs to reveal the content, providing a great experience on mobile devices where space is scarce.
@@ -46,7 +46,7 @@
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/accordion">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy">
   </a>
 </p>
 

--- a/packages/mjml-body/README.md
+++ b/packages/mjml-body/README.md
@@ -12,7 +12,7 @@ This is the starting point of your email.
 
 <p align="center">
   <a target="_blank" href="https://mjml.io/try-it-live/components/body">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -1,7 +1,8 @@
 ## mjml-button
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/6558790/12751346/fd993192-c9bc-11e5-8c91-37d616bf5874.png" alt="desktop" width="150px" />
+  <img src="https://cloud.githubusercontent.com/assets/6558790/12751346/fd993192-c9bc-11e5-8c91-37d616bf5874.png"
+      alt="desktop" width="150px">
 </p>
 
 Displays a customizable button.
@@ -22,7 +23,7 @@ Displays a customizable button.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/button">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-carousel/README.md
+++ b/packages/mjml-carousel/README.md
@@ -1,7 +1,7 @@
 ## mjml-carousel
 
 <p align="center">
-  <img src="http://i.imgur.com/wHqIzgd.gif" alt="desktop" />
+  <img src="http://i.imgur.com/wHqIzgd.gif" alt="desktop">
 </p>
 
 `mjml-carousel` displays a gallery of images or "carousel". Readers can interact by hovering and clicking on thumbnails depending on the email client they use.
@@ -26,7 +26,7 @@ This component enables you to set the styles of the carousel elements.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/carousel">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy">
   </a>
 </p>
 

--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -22,7 +22,7 @@ Every single column has to contain something because they are responsive contain
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/column">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-divider/README.md
+++ b/packages/mjml-divider/README.md
@@ -16,7 +16,7 @@ Displays a horizontal divider that can be customized like a HTML border.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/divider">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-group/README.md
+++ b/packages/mjml-group/README.md
@@ -3,12 +3,14 @@
 
 <p align="center">
   Desktop<br />
-  <img src="https://cloud.githubusercontent.com/assets/570317/15677458/a6ad2c1c-274a-11e6-8fdf-6853d748ef27.png" />
+  <img src="https://cloud.githubusercontent.com/assets/570317/15677458/a6ad2c1c-274a-11e6-8fdf-6853d748ef27.png"
+      alt="example presentation of columns for desktop; because of the wide screen, mj-columns are side-by-side">
 </p>
 
 <p align="center">
   Mobile<br />
-  <img src="https://cloud.githubusercontent.com/assets/570317/15677396/6bb62708-274a-11e6-8c59-0d8b3944a2ae.png" />
+  <img src="https://cloud.githubusercontent.com/assets/570317/15677396/6bb62708-274a-11e6-8c59-0d8b3944a2ae.png"
+      alt="example presentation of columns for mobile; because the mj-columns are in an mj-group, they still appear side-by-side">
 </p>
 
 mj-group allows you to prevent columns from stacking on mobile. To do so, wrap the columns inside a `mj-group` tag, so they'll stay side by side on mobile.
@@ -39,7 +41,9 @@ mj-group allows you to prevent columns from stacking on mobile. To do so, wrap t
 ```
 
 <p align="center">
-  <a href="https://mjml.io/try-it-live/components/group"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
+  <a href="https://mjml.io/try-it-live/components/group">
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
+  </a>
 </p>
 
 <aside class="notice">

--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -21,7 +21,7 @@ This tag allows you to import fonts if used in your MJML document
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/head-font">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-head-preview/README.md
+++ b/packages/mjml-head-preview/README.md
@@ -21,7 +21,7 @@ This tag allows you to set the preview that will be displayed in the inbox of th
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/head-preview">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-head-style/README.md
+++ b/packages/mjml-head-style/README.md
@@ -36,7 +36,7 @@ Here is an example showing the use in combination with the `css-class` attribute
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/head-style">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -5,7 +5,7 @@ Display a section with a background image and some content inside (mj-text, mj-b
 Fixed height  
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15354833/bfe7faaa-1cef-11e6-8d38-15e8951b6636.png" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15354833/bfe7faaa-1cef-11e6-8d38-15e8951b6636.png">
 </p>
 
 ```xml
@@ -39,14 +39,15 @@ Fixed height
 
  <p align="center">
    <a href="https://mjml.io/try-it-live/components/hero">
-     <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+     <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg"
+         alt="try it live">
    </a>
  </p>
 
 Fluid height
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15354867/fc2f404a-1cef-11e6-92ac-92de9e438210.png" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15354867/fc2f404a-1cef-11e6-92ac-92de9e438210.png">
 </p>
 
 ```xml
@@ -81,7 +82,8 @@ Fluid height
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/hero/1">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg"
+        alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -17,7 +17,7 @@ Note that if no width is provided, the image will use the parent column width.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/image">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -1,6 +1,6 @@
 ## mjml-image
 
-Displays a responsive image in your email. It is similar to the HTML `<img />` tag.
+Displays a responsive image in your email. It is similar to the HTML `<img>` tag.
 Note that if no width is provided, the image will use the parent column width.
 
 ```xml

--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -1,7 +1,7 @@
 ## mjml-navbar
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px">
 </p>
 
 Displays a menu for navigation with an optional hamburger mode for mobile devices.
@@ -25,7 +25,8 @@ Displays a menu for navigation with an optional hamburger mode for mobile device
 
 <p align="center">
   <a target="_blank" href="https://mjml.io/try-it-live/components/navbar">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg"
+        alt="try it live">
   </a>
 </p>
 
@@ -37,7 +38,7 @@ Individual links of the menu should we wrapped inside mj-navbar.
 Standard Desktop:
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px">
 </p>
 
 Standard Mobile:

--- a/packages/mjml-raw/README.md
+++ b/packages/mjml-raw/README.md
@@ -15,7 +15,7 @@ If placed inside `<mj-head>`, its content will be added at the end of the `<head
 
 <p align="center">
   <a target="_blank" href="https://mjml.io/try-it-live/components/raw">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-spacer/README.md
+++ b/packages/mjml-spacer/README.md
@@ -18,7 +18,7 @@ Displays a blank space.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/spacer">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -20,7 +20,7 @@ This tag allows you to display text in your email.
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/text">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 

--- a/packages/mjml-wrapper/README.md
+++ b/packages/mjml-wrapper/README.md
@@ -1,7 +1,7 @@
 ## mjml-wrapper
 
 <p align="center">
-  <img src="http://i.imgur.com/6YKq83B.png" alt="wrapper" />
+  <img src="http://i.imgur.com/6YKq83B.png" alt="wrapper">
 </p>
 
 Wrapper enables to wrap multiple sections together. It's especially useful to achieve nested layouts with shared border or background images across sections.
@@ -29,7 +29,7 @@ Wrapper enables to wrap multiple sections together. It's especially useful to ac
 
 <p align="center">
   <a href="https://mjml.io/try-it-live/components/wrapper">
-    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" />
+    <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live">
   </a>
 </p>
 


### PR DESCRIPTION
# Included Here #

* A copy of `packages\mjml-image\README.md`, different only by changing

> It is similar to the &lt;img /&gt; tag.

to

> It is similar to the HTML &lt;img&gt; tag.

* Changes to some instances of the HTML code we execute in the documentation for modern browsers. I deleted the closing tags on `<img>` tags.

* Some addition of `alt` attributes on `<img>` tags to help accessibility. Some of this might conflict with other such work in other commits. 😔 Pick the ones you prefer.

* No changes to example code in our documentation (visible to our readers). No closing tags found.

* _No changes to any JavaScript file._