### PR TITLE
Fix #1480 and #1767; change "mjml-" to "mj-" everywhere appropriate in documentation (#1480); remove MJML 3 wording in Docs > Basic layout example > Social Icons (#1767); documentation only

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -197,4 +197,5 @@ This section is a 3-columns-based section. Please notice you can make the paddin
 </mj-section>
 
 ```
-The MJML standard components library comes with a `mj-social` component. Here, we're going to use `facebook` only.
+The MJML standard components library comes with a `mj-social` component.
+Here, we're going to use `facebook` only.

--- a/doc/mjml-chart.md
+++ b/doc/mjml-chart.md
@@ -1,9 +1,9 @@
-## mjml-chart
+## mj-chart
 
 Thanks to [image-charts](https://image-charts.com/) for their contribution with this component. It's available on [Github](https://github.com/image-charts/mjml-charts) and [NPM](https://www.npmjs.com/package/mjml-chart).
 
 <p align="center">
-  <img src="https://puu.sh/tjIVp/cd01defdac.png" alt="mjml-charts" />
+  <img src="https://puu.sh/tjIVp/cd01defdac.png" alt="mj-chart demo" />
 </p>
 
 Displays charts as images in your email.

--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -1,10 +1,10 @@
-## mjml-accordion
+## mj-accordion
 
 <p align="center">
   <img src="http://i.imgur.com/C4S9MVc.gif" alt="accordion" />
 </p>
 
-`mjml-accordion` is an interactive MJML component to stack content in tabs, so the information is collapsed and only the titles are visible. Readers can interact by clicking on the tabs to reveal the content, providing a great experience on mobile devices where space is scarce.
+`mj-accordion` is an interactive MJML component to stack content in tabs, so the information is collapsed and only the titles are visible. Readers can interact by clicking on the tabs to reveal the content, providing a great experience on mobile devices where space is scarce.
 
 ```xml
 <mjml>
@@ -75,7 +75,7 @@ padding-left | px | padding left | n/a
 padding-right | px | padding right | n/a
 padding-top | px | padding top | n/a
 
-### mjml-accordion-element
+### mj-accordion-element
 
 This component enables you to create a accordion pane
 
@@ -93,7 +93,7 @@ icon-width | n/a | icon height | 32px
 icon-wrapped-alt | n/a | alt text when accordion is wrapped | +
 icon-wrapped-url | n/a | icon when accordion is wrapped | http://i.imgur.com/bIXv1bk.png
 
-### mjml-accordion-title
+### mj-accordion-title
 
 This component enables you to add and style a title to your accordion
 
@@ -110,7 +110,7 @@ padding-left | px | padding left | n/a
 padding-right | px | padding right | n/a
 padding-top | px | padding top | n/a
 
-### mjml-accordion-text
+### mj-accordion-text
 
 This component enables you to add and style a text to your accordion
 

--- a/packages/mjml-body/README.md
+++ b/packages/mjml-body/README.md
@@ -1,4 +1,4 @@
-## mjml-body
+## mj-body
 
 This is the starting point of your email.
 

--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -1,4 +1,4 @@
-## mjml-button
+## mj-button
 
 <p align="center">
   <img src="https://cloud.githubusercontent.com/assets/6558790/12751346/fd993192-c9bc-11e5-8c91-37d616bf5874.png" alt="desktop" width="150px" />
@@ -44,7 +44,6 @@ font-size                   | px          | text size                           
 font-style                  | string      | normal/italic/oblique                            | n/a
 font-weight                 | number      | text thickness                                   | normal
 height                      | px          | button height                                    | n/a
-letter-spacing              | px          | letter spacing                                   | none
 href                        | link        | link to be triggered when the button is clicked  | n/a
 inner-padding               | px          | inner button padding                             | 10px 25px
 line-height                 | px/%/none   | line-height on link                              | 120%

--- a/packages/mjml-carousel/README.md
+++ b/packages/mjml-carousel/README.md
@@ -1,10 +1,10 @@
-## mjml-carousel
+## mj-carousel
 
 <p align="center">
   <img src="http://i.imgur.com/wHqIzgd.gif" alt="desktop" />
 </p>
 
-`mjml-carousel` displays a gallery of images or "carousel". Readers can interact by hovering and clicking on thumbnails depending on the email client they use.
+`mj-carousel` displays a gallery of images or "carousel". Readers can interact by hovering and clicking on thumbnails depending on the email client they use.
 
 This component enables you to set the styles of the carousel elements.
 
@@ -38,8 +38,8 @@ background-color | string | column background color | none
 border-radius | px | border radius | n/a
 css-class | string | class name, added to the root HTML element created | n/a
 icon-width | px | width of the icons on left and right of the main image | 44px
-left-icon | url | icon on the left of the main image | https://i.imgur.com/xTh3hln.png
-right-icon | url | icon on the right of the main image | https://i.imgur.com/os7o9kz.png
+left-icon | url | icon on the left of the main image | https://mjml.io/assets/img/left-arrow.png
+right-icon | url | icon on the right of the main image | https://mjml.io/assets/img/right-arrow.png
 tb-border | css border format | border of the thumbnails | none
 tb-border-radius | px | border-radius of the thumbnails | none
 tb-hover-border-color | string | css border color of the hovered thumbnail | none
@@ -47,7 +47,7 @@ tb-selected-border-color | string | css border color of the selected thumbnail |
 tb-width | px | thumbnail width | null
 thumbnails | String | display or not the thumbnails (visible | hidden)
 
-### mjml-carousel-image
+### mj-carousel-image
 
 This component enables you to add and style the images in the carousel.
 
@@ -61,3 +61,4 @@ src | url | image source | n/a
 target | string | link target on click | \_blank
 thumbnails-src | url | image source to have a thumbnail different than the image it's linked to | null
 title | string | tooltip & accessibility | n/a
+

--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -1,4 +1,4 @@
-## mjml-column
+## mj-column
 
 Columns enable you to horizontally organize the content within your sections. They must be located under `mj-section` tags in order to be considered by the engine.
 To be responsive, columns are expressed in terms of percentage.
@@ -42,7 +42,7 @@ border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
-border-radius       | percent/px  | border radius (only applied on the background-color, not the border) | n/a
+border-radius       | percent/px  | border radius                  | n/a
 width               | percent/px  | column width                   | (100 / number of non-raw elements in section)%
 vertical-align      | string      | middle/top/bottom              | top
 padding             | px          | supports up to 4 parameters    | n/a
@@ -51,3 +51,4 @@ padding-bottom      | px          | section bottom offset          | n/a
 padding-left        | px          | section left offset            | n/a
 padding-right       | px          | section right offset           | n/a
 css-class           | string      | class name, added to the root HTML element created | n/a
+

--- a/packages/mjml-divider/README.md
+++ b/packages/mjml-divider/README.md
@@ -1,4 +1,4 @@
-## mjml-divider
+## mj-divider
 
 Displays a horizontal divider that can be customized like a HTML border.
 

--- a/packages/mjml-group/README.md
+++ b/packages/mjml-group/README.md
@@ -1,14 +1,16 @@
-## mjml-group
+## mj-group
 
 
 <p align="center">
   Desktop<br />
-  <img src="https://cloud.githubusercontent.com/assets/570317/15677458/a6ad2c1c-274a-11e6-8fdf-6853d748ef27.png" />
+  <img src="https://cloud.githubusercontent.com/assets/570317/15677458/a6ad2c1c-274a-11e6-8fdf-6853d748ef27.png"
+       alt="easy and quick; responsive" />
 </p>
 
 <p align="center">
   Mobile<br />
-  <img src="https://cloud.githubusercontent.com/assets/570317/15677396/6bb62708-274a-11e6-8c59-0d8b3944a2ae.png" />
+  <img src="https://cloud.githubusercontent.com/assets/570317/15677396/6bb62708-274a-11e6-8c59-0d8b3944a2ae.png"
+      alt="easy and quick; responsive" />
 </p>
 
 mj-group allows you to prevent columns from stacking on mobile. To do so, wrap the columns inside a `mj-group` tag, so they'll stay side by side on mobile.

--- a/packages/mjml-head-attributes/README.md
+++ b/packages/mjml-head-attributes/README.md
@@ -1,4 +1,4 @@
-## mjml-attributes
+## mj-attributes
 
 This tag allows you to modify default attributes on a `mj-tag` and add `mj-class` to them.
 

--- a/packages/mjml-head-breakpoint/README.md
+++ b/packages/mjml-head-breakpoint/README.md
@@ -1,4 +1,4 @@
-## mjml-breakpoint
+## mj-breakpoint
 This tag allows you to control on which breakpoint the layout should go desktop/mobile.
 
 ```xml

--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -1,4 +1,4 @@
-## mjml-font
+## mj-font
 
 This tag allows you to import fonts if used in your MJML document
 

--- a/packages/mjml-head-preview/README.md
+++ b/packages/mjml-head-preview/README.md
@@ -1,4 +1,4 @@
-## mjml-preview
+## mj-preview
 
 This tag allows you to set the preview that will be displayed in the inbox of the recipient.
 

--- a/packages/mjml-head-style/README.md
+++ b/packages/mjml-head-style/README.md
@@ -1,4 +1,4 @@
-## mjml-style
+## mj-style
 
 This tag allows you to set CSS styles that will be applied to the <b>HTML</b> in your MJML document as well as the HTML outputted. The CSS styles will be added to the head of the rendered HTML by default, but can also be inlined by using the `inline="inline"` attribute.
 

--- a/packages/mjml-head-title/README.md
+++ b/packages/mjml-head-title/README.md
@@ -1,4 +1,4 @@
-## mjml-title
+## mj-title
 
 This tag allows you to set the title of an MJML document
 

--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -1,11 +1,12 @@
-## mjml-hero
+## mj-hero
 
 Display a section with a background image and some content inside (mj-text, mj-button, mj-image ...) wrapped in mj-hero-content component
 
 Fixed height  
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15354833/bfe7faaa-1cef-11e6-8d38-15e8951b6636.png" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15354833/bfe7faaa-1cef-11e6-8d38-15e8951b6636.png"
+     alt="demo background picture with fixed height" />
 </p>
 
 ```xml
@@ -46,7 +47,8 @@ Fixed height
 Fluid height
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15354867/fc2f404a-1cef-11e6-92ac-92de9e438210.png" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15354867/fc2f404a-1cef-11e6-92ac-92de9e438210.png"
+      alt="demo background picture with fixed height" />
 </p>
 
 ```xml

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -1,4 +1,4 @@
-## mjml-image
+## mj-image
 
 Displays a responsive image in your email. It is similar to the HTML `<img />` tag.
 Note that if no width is provided, the image will use the parent column width.

--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -1,7 +1,8 @@
-## mjml-navbar
+## mj-navbar
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png"
+      alt="example desktop width navbar" width="800px" />
 </p>
 
 Displays a menu for navigation with an optional hamburger mode for mobile devices.
@@ -29,7 +30,7 @@ Displays a menu for navigation with an optional hamburger mode for mobile device
   </a>
 </p>
 
-### mjml-navbar
+### mj-navbar
 
 Individual links of the menu should we wrapped inside mj-navbar.
 
@@ -37,19 +38,23 @@ Individual links of the menu should we wrapped inside mj-navbar.
 Standard Desktop:
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png" width="800px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317906/d6cef510-1c23-11e6-83d7-31e4e4f8ba2a.png"
+      alt="example desktop width navbar" width="800px" />
 </p>
 
 Standard Mobile:
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317917/e514d0a4-1c23-11e6-8e5a-c23da9ac1d4e.png" width="318px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317917/e514d0a4-1c23-11e6-8e5a-c23da9ac1d4e.png"
+      alt="example mobile width navbar" width="318px" />
 </p>
 
 Mode hamburger enabled:
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/1830348/15317922/f01c5c24-1c23-11e6-9b0c-95b0602da260.gif" width="309px" />
+  <img src="https://cloud.githubusercontent.com/assets/1830348/15317922/f01c5c24-1c23-11e6-9b0c-95b0602da260.gif"
+      alt="hamburger mode animation shows menu expansion after clicking hamburger icon"
+      width="309px" />
 </p>
 
 <aside class="notice">
@@ -82,7 +87,7 @@ ico-text-decoration         | string             | hamburger icon text decoratio
 ico-text-transform          | string             | hamburger icon text transformation none/capitalize/uppercase/lowercase (hamburger mode required) | none
 
 
-### mjml-navbar-link
+### mj-navbar-link
 
 
 This component should be used to display an individual link in the navbar.

--- a/packages/mjml-raw/README.md
+++ b/packages/mjml-raw/README.md
@@ -1,4 +1,4 @@
-## mjml-raw
+## mj-raw
 
 Displays raw HTML that is not going to be parsed by the MJML engine. Anything left inside this tag should be raw, responsive HTML.
 If placed inside `<mj-head>`, its content will be added at the end of the `<head>`.

--- a/packages/mjml-section/README.md
+++ b/packages/mjml-section/README.md
@@ -1,4 +1,4 @@
-## mjml-section
+## mj-section
 
 Sections are intended to be used as rows within your email.
 They will be used to structure the layout.
@@ -40,7 +40,7 @@ background-url      | url         | background url                 | n/a
 border              | string      | css border format              | none
 border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
-border-radius       | px          | border radius (only applied on the background-color, not the border) | n/a
+border-radius       | px          | border radius                  | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
 css-class           | string      | class name, added to the root HTML element created | n/a

--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -1,4 +1,4 @@
-## mjml-social
+## mj-social
 
 <p align="center">
   <img src="https://cloud.githubusercontent.com/assets/6558790/12751360/0c78ce48-c9bd-11e5-98ca-4a2ac9e6341b.png" alt="desktop" style="width: 250px;"/>

--- a/packages/mjml-spacer/README.md
+++ b/packages/mjml-spacer/README.md
@@ -1,4 +1,4 @@
-## mjml-spacer
+## mj-spacer
 
 Displays a blank space.
 

--- a/packages/mjml-table/README.md
+++ b/packages/mjml-table/README.md
@@ -1,4 +1,4 @@
-## mjml-table
+## mj-table
 
 This tag allows you to display table and filled it with data. It only accepts plain HTML.
 
@@ -8,7 +8,7 @@ This tag allows you to display table and filled it with data. It only accepts pl
     <mj-section>
       <mj-column>
         <mj-table>
-          <tr style="border-bottom:1px solid #ecedee;text-align:left;">
+          <tr style="border-bottom:1px solid #ecedee;text-align:left;padding:15px 0;">
             <th style="padding: 0 15px 0 0;">Year</th>
             <th style="padding: 0 15px;">Language</th>
             <th style="padding: 0 0 0 15px;">Inspired from</th>

--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -1,4 +1,4 @@
-## mjml-text
+## mj-text
 
 This tag allows you to display text in your email.
 

--- a/packages/mjml-wrapper/README.md
+++ b/packages/mjml-wrapper/README.md
@@ -1,4 +1,4 @@
-## mjml-wrapper
+## mj-wrapper
 
 <p align="center">
   <img src="http://i.imgur.com/6YKq83B.png" alt="wrapper" />


### PR DESCRIPTION
# Confusing Factor #

The branch name on this commit is correct "fix-1767". It could have been better as "fix-1767 and -1480".

The commit message correctly refers to Issue #1480. It could have been better to include some material about #1767. The most important of that material is here.

Fixes for both Issue #1480 and #1767 are here.

** Later update: The fix for #1767 is here because the change is not yet in our production documentation. It was in PR #1768 and iRyusa merged that into `mjmlio:next` on Jan 14. Perhaps that's a part of `next` that'll be in the next push to production and is best to ignore here. It is the only change in this commit to file _doc/basic.md_ and pops up first when I use _git diff_.

# Included Here #

* For each occurrence of `mjml-` relevant to the user perspective: Change to `mj-`.

* Adding some alt attributes to reduce IDE complaints about missing required attributes and to demonstrate more compliant HTML.

* For the paragraph cited in Issue #1767, two sentences removed. The paragraph now reads

```
The MJML standard components library comes with a `mj-social` component.
Here, we're going to use facebook only.
```

* _No change to any JavaScript file._