### PR TITLE
Background-position and background-size working in Outlook for windows desktop and yahoo

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -55,8 +55,9 @@ export default class MjSection extends BodyComponent {
     const background = this.getAttribute('background-url')
       ? { 
         background: this.getBackground(), 
+        // background size, repeat and position has to be seperate since yahoo does not support shorthand background css property
         'background-position': `${this.getAttribute('background-position-x')} ${this.getAttribute('background-position-y')}`,
-        // background size and position has to be seperate since yahoo does not support shorthand background css property
+        'background-repeat': this.getAttribute('background-repeat'),
         'background-size': this.getAttribute('background-size'),
       }
       : {

--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -202,37 +202,40 @@ export default class MjSection extends BodyComponent {
 
     const { containerWidth } = this.context
 
-    let vOriginPosX, vOriginPosY
+    let vOriginPosX
+    let vOriginPosY
     let vSizeAttributes = {}
 
     // this logic is different when using repeat or no-repeat
-    if (this.getAttribute('background-repeat') == "repeat") {
-      switch (this.getAttribute('background-position-x')) {
-        case 'left': vOriginPosX = '0'; break;
-        case 'center': vOriginPosX = '0.5'; break;
-        case 'right': vOriginPosX = '1'; break;
-        default: vOriginPosX = '0.5'; break;
-      }
-      switch (this.getAttribute('background-position-y')) {
-        case 'top': vOriginPosY = '0'; break;
-        case 'center': vOriginPosY = '0.5'; break;
-        case 'bottom': vOriginPosY = '1'; break;
-        default: vOriginPosY = '0'; break;
-      }
-    } else {
-      switch (this.getAttribute('background-position-x')) {
-        case 'left': vOriginPosX = '-0.5'; break;
-        case 'center': vOriginPosX = '0'; break;
-        case 'right': vOriginPosX = '0.5'; break;
-        default: vOriginPosX = '0'; break;
-      }
-      switch (this.getAttribute('background-position-y')) {
-        case 'top': vOriginPosY = '-0.5'; break;
-        case 'center': vOriginPosY = '0'; break;
-        case 'bottom': vOriginPosY = '0.5'; break;
-        default: vOriginPosY = '-1'; break;
-      }
+    switch (this.getAttribute('background-position-x')) {
+      case 'left': 
+        vOriginPosX = this.getAttribute('background-repeat') === "repeat" ? '0' : '-0.5'
+        break
+      case 'center': 
+        vOriginPosX = this.getAttribute('background-repeat') === "repeat" ? '0.5' : '0'
+        break
+      case 'right': 
+        vOriginPosX = this.getAttribute('background-repeat') === "repeat" ? '1' : '0.5'
+        break
+      default: 
+        vOriginPosX = this.getAttribute('background-repeat') === "repeat" ? '0.5' : '0'
+        break
     }
+    switch (this.getAttribute('background-position-y')) {
+      case 'top':
+        vOriginPosY = this.getAttribute('background-repeat') === "repeat" ? '0' : '-0.5'
+        break
+      case 'center':
+        vOriginPosY = this.getAttribute('background-repeat') === "repeat" ? '0.5' : '0'
+        break
+      case 'bottom':
+        vOriginPosY = this.getAttribute('background-repeat') === "repeat" ? '1' : '0.5'
+        break
+      default:
+        vOriginPosY = this.getAttribute('background-repeat') === "repeat" ? '0' : '-0.5'
+        break
+    }
+
 
     // If background size is either cover or contain, we tell VML to keep the aspect 
     // and fill the entire element. 
@@ -240,7 +243,7 @@ export default class MjSection extends BodyComponent {
       this.getAttribute('background-size') === 'contain') {
       vSizeAttributes = {
         size: '1,1',
-        aspect: this.getAttribute('background-size') == 'cover' ? 'atleast' : 'atmost',
+        aspect: this.getAttribute('background-size') === 'cover' ? 'atleast' : 'atmost',
       }
     }
 
@@ -261,7 +264,7 @@ export default class MjSection extends BodyComponent {
           src: this.getAttribute('background-url'),
           color: this.getAttribute('background-color'),
           type: this.getAttribute('background-repeat') === 'repeat' ? 'tile' : 'frame',
-          ...vSizeAttributes
+          ...vSizeAttributes,
         })} />
         <v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0">
       <![endif]-->

--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -219,7 +219,18 @@ export default class MjSection extends BodyComponent {
         default: vOriginPosY = '0'; break;
       }
     } else {
-
+      switch (this.getAttribute('background-position-x')) {
+        case 'left': vOriginPosX = '-0.5'; break;
+        case 'center': vOriginPosX = '0'; break;
+        case 'right': vOriginPosX = '0.5'; break;
+        default: vOriginPosX = '0'; break;
+      }
+      switch (this.getAttribute('background-position-y')) {
+        case 'top': vOriginPosY = '-0.5'; break;
+        case 'center': vOriginPosY = '0'; break;
+        case 'bottom': vOriginPosY = '0.5'; break;
+        default: vOriginPosY = '-1'; break;
+      }
     }
 
     // If background size is either cover or contain, we tell VML to keep the aspect 
@@ -248,7 +259,7 @@ export default class MjSection extends BodyComponent {
           position: `${vOriginPosX}, ${vOriginPosY}`,
           src: this.getAttribute('background-url'),
           color: this.getAttribute('background-color'),
-          type: 'tile',
+          type: this.getAttribute('background-repeat') === 'repeat' ? 'tile' : 'frame',
           ...vSizeAttributes
         })} />
         <v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0">


### PR DESCRIPTION
Based on: https://github.com/mjmlio/mjml/issues/1814

Background position and background size is now working with yahoo and outlook desktop.
I have only added `background-posiiton-x` and `background-position-y`, as it seemed to complicated to implement just `background-position`.
`background-repeat: no-repeat` will now also work for outlook, the only issue is that the image will be stretched if `background-size` is not set to either `cover` or `contain`.

Tests:
https://litmus.com/builder/9ebafc2
https://litmus.com/builder/fa7f3af
https://litmus.com/builder/06bf715
https://litmus.com/builder/2f46c4e
https://litmus.com/builder/ed180d2
https://litmus.com/builder/3fb5dbf

Edit:
I have added support for percentage values instead of just top, center, bottom, left and right.
Here are my tests for that
https://litmus.com/builder/4cdafaa
https://litmus.com/builder/ab592f7