### PR TITLE
Fix 1848

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -36,6 +36,7 @@ export default async () => {
     )
 
   const argv = yargs
+    .version(false) // cf. https://github.com/yargs/yargs/issues/961
     .options({
       r: {
         alias: 'read',


### PR DESCRIPTION
Since version is now enabled by default on yargs, we need to disable it before giving it an alias
cf. https://github.com/yargs/yargs/issues/961