### PR TITLE
add support for vertical-align to social-element

### DIFF
--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -95,6 +95,7 @@ src                         | url         | image source                  | Each
 target                      | string      | link target                   | \_blank
 title                       | string      | img title attribute           | none
 text-decoration             | string      | underline/overline/none       | none
+vertical-align              | string      | top/middle/bottom             | middle
 
 Supported networks with a share url:  
 - facebook  

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -116,7 +116,7 @@ export default class MjSocialElement extends BodyComponent {
     title: 'string',
     target: 'string',
     'text-decoration': 'string',
-    'vertical-align': 'enum(top,middle,bottom)'
+    'vertical-align': 'enum(top,middle,bottom)',
   }
 
   static defaultAttributes = {
@@ -130,7 +130,7 @@ export default class MjSocialElement extends BodyComponent {
     'text-padding': '4px 4px 4px 0',
     target: '_blank',
     'text-decoration': 'none',
-    'vertical-align': 'middle'
+    'vertical-align': 'middle',
   }
 
   getStyles() {
@@ -143,7 +143,7 @@ export default class MjSocialElement extends BodyComponent {
     return {
       td: {
         padding: this.getAttribute('padding'),
-        'vertical-align': this.getAttribute('vertical-align')
+        'vertical-align': this.getAttribute('vertical-align'),
       },
       table: {
         background: backgroundColor,

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -116,6 +116,7 @@ export default class MjSocialElement extends BodyComponent {
     title: 'string',
     target: 'string',
     'text-decoration': 'string',
+    'vertical-align': 'enum(top,middle,bottom)'
   }
 
   static defaultAttributes = {
@@ -129,6 +130,7 @@ export default class MjSocialElement extends BodyComponent {
     'text-padding': '4px 4px 4px 0',
     target: '_blank',
     'text-decoration': 'none',
+    'vertical-align': 'middle'
   }
 
   getStyles() {
@@ -141,6 +143,7 @@ export default class MjSocialElement extends BodyComponent {
     return {
       td: {
         padding: this.getAttribute('padding'),
+        'vertical-align': this.getAttribute('vertical-align')
       },
       table: {
         background: backgroundColor,


### PR DESCRIPTION
This adds support for `vertical-align` to the `mj-social-element` tag.

Local screenshot:
<img width="759" alt="Screen Shot 2020-04-03 at 3 55 31 PM" src="https://user-images.githubusercontent.com/3782630/78399899-c3118800-75c3-11ea-9e8d-91cff30da823.png">

Litmus screenshot:
<img width="952" alt="Screen Shot 2020-04-03 at 3 56 07 PM" src="https://user-images.githubusercontent.com/3782630/78399917-cad12c80-75c3-11ea-9da3-0434bdcf887e.png">

Code snippet using new tag:
```
<mj-social icon-size="24px" mode="horizontal" padding="0 24px 24px">
    <mj-social-element name="facebook" vertical-align="top">
        <h4 style="margin:0;"><strong>This is a test</strong></h4>
        <div style="color:#5D5D5D;">Test sample sentence with some content</div>
        <br />
        <div style="color:#5D5D5D;">Another test sample sentence with some content.</div>
        <br />
        <div style="color:#5D5D5D;">Yet another test sample sentence with some content </div>
    </mj-social-element>
</mj-social>
```

