### PR TITLE
fix-1889, `mj-button` attribute table lacks an entry for `letter-spacing`

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -46,6 +46,7 @@ font-weight                 | number      | text thickness                      
 height                      | px          | button height                                    | n/a
 href                        | link        | link to be triggered when the button is clicked  | n/a
 inner-padding               | px          | inner button padding                             | 10px 25px
+letter-spacing              | px          | letter spacing                                   | n/a
 line-height                 | px/%/none   | line-height on link                              | 120%
 padding                     | px          | supports up to 4 parameters                      | 10px 25px
 padding-bottom              | px          | bottom offset                                    | n/a


### PR DESCRIPTION
documentation only
no change to any JavaScript file

add entry for `letter-spacing` to `mj-button` attribute table