### PR TITLE
Body width must be defined in px instead of %

### DIFF
--- a/packages/mjml-body/src/index.js
+++ b/packages/mjml-body/src/index.js
@@ -2,7 +2,7 @@ import { BodyComponent } from 'mjml-core'
 
 export default class MjBody extends BodyComponent {
   static allowedAttributes = {
-    width: 'unit(px,%)',
+    width: 'unit(px)',
     'background-color': 'color',
   }
 


### PR DESCRIPTION
Remove % as supported unit, documentation is right about this dunno why we haven't seen this one yet