### PR TITLE
fix wrapper docs for background-url

### DIFF
--- a/packages/mjml-wrapper/README.md
+++ b/packages/mjml-wrapper/README.md
@@ -43,7 +43,7 @@ changed to 100%.
 
 <aside class="notice">
   If you're using a background-url on a `mj-wrapper` then do not add one into a section within the mj-wrapper. Outlook Desktop doesn't support nested VML, so it will most likely break your email.
-  Also, if you use a background-color on mj-wrapper and a background-url on its section/hero child, the background-color will be over the background-image on Outlook. There is no way to keep the vml image over the content and under the wrapper background-color due to z-index being ignored on most tags.
+  Also, if you use a background-color on mj-wrapper and a background-url on its section/hero child, the background-color will be over the background-url on Outlook. There is no way to keep the vml image over the content and under the wrapper background-color due to z-index being ignored on most tags.
 </aside>
 
 


### PR DESCRIPTION
background-image property was mistakenly used instead of background-url when describing Outlook issue.