### PR TITLE
change to new twitter share link

### DIFF
--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -10,7 +10,7 @@ const defaultSocialNetworks = {
     src: `${IMG_BASE_URL}facebook.png`,
   },
   twitter: {
-    'share-url': 'https://twitter.com/home?status=[[URL]]',
+    'share-url': 'https://twitter.com/intent/tweet?url=[[URL]]',
     'background-color': '#55acee',
     src: `${IMG_BASE_URL}twitter.png`,
   },


### PR DESCRIPTION
I looks like twitter have changed the share link.
```
https://twitter.com/intent/tweet?text=search%20for%20something&url=https://google.com
```
This updates SocialElement.js to use this new intent link.
It could be improved by also supporting the `text` parameter.