### PR TITLE
Automatically normalize lodash imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,5 +12,6 @@ module.exports = {
       },
     ],
     'add-module-exports',
+    'lodash',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/register": "^7.8.6",
     "babel-eslint": "^7.2.3",
     "babel-plugin-add-module-exports": "^1.0.2",
+    "babel-plugin-lodash": "^3.3.4",
     "es6-promisify": "^5.0.0",
     "eslint": "^4.5.0",
     "eslint-config-airbnb-base": "^11.3.2",

--- a/packages/mjml-carousel/src/Carousel.js
+++ b/packages/mjml-carousel/src/Carousel.js
@@ -1,8 +1,5 @@
 import { BodyComponent } from 'mjml-core'
-import range from 'lodash/range'
-import repeat from 'lodash/repeat'
-import min from 'lodash/min'
-import map from 'lodash/map'
+import { range, repeat, min, map } from 'lodash'
 import crypto from 'crypto'
 
 import { msoConditionalTag } from 'mjml-core/lib/helpers/conditionalTag'

--- a/packages/mjml-core/src/components.js
+++ b/packages/mjml-core/src/components.js
@@ -1,4 +1,4 @@
-import kebabCase from 'lodash/kebabCase'
+import { kebabCase } from 'lodash'
 
 const components = {}
 

--- a/packages/mjml-core/src/helpers/fonts.js
+++ b/packages/mjml-core/src/helpers/fonts.js
@@ -1,5 +1,4 @@
-import forEach from 'lodash/forEach'
-import map from 'lodash/map'
+import { forEach, map } from 'lodash'
 
 // eslint-disable-next-line import/prefer-default-export
 export function buildFontsTags(content, inlineStyle, fonts = {}) {

--- a/packages/mjml-core/src/types/enum.js
+++ b/packages/mjml-core/src/types/enum.js
@@ -1,4 +1,4 @@
-import escapeRegExp from 'lodash/escapeRegExp'
+import { escapeRegExp } from 'lodash'
 import Type from './type'
 
 export const matcher = /^enum/gim

--- a/packages/mjml-core/src/types/type.js
+++ b/packages/mjml-core/src/types/type.js
@@ -1,5 +1,4 @@
-import some from 'lodash/some'
-import find from 'lodash/find'
+import { some, find } from 'lodash'
 import typesConstructors from './index'
 
 // Avoid recreate existing types

--- a/packages/mjml-core/src/types/unit.js
+++ b/packages/mjml-core/src/types/unit.js
@@ -1,4 +1,4 @@
-import escapeRegExp from 'lodash/escapeRegExp'
+import { escapeRegExp } from 'lodash'
 import Type from './type'
 
 export const matcher = /^(unit|unitWithNegative)\(.*\)/gim

--- a/packages/mjml-head-attributes/src/index.js
+++ b/packages/mjml-head-attributes/src/index.js
@@ -1,6 +1,4 @@
-import forEach from 'lodash/forEach'
-import omit from 'lodash/omit'
-import reduce from 'lodash/reduce'
+import { forEach, omit, reduce } from 'lodash'
 
 import { HeadComponent } from 'mjml-core'
 

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -1,4 +1,4 @@
-import min from 'lodash/min'
+import { min } from 'lodash'
 
 import { BodyComponent } from 'mjml-core'
 

--- a/packages/mjml-parser-xml/src/helpers/convertBooleansOnAttrs.js
+++ b/packages/mjml-parser-xml/src/helpers/convertBooleansOnAttrs.js
@@ -1,4 +1,4 @@
-import mapValues from 'lodash/mapValues'
+import { mapValues } from 'lodash'
 
 /**
  * Convert "true" and "false" string attributes values

--- a/packages/mjml-parser-xml/src/helpers/setEmptyAttributes.js
+++ b/packages/mjml-parser-xml/src/helpers/setEmptyAttributes.js
@@ -1,4 +1,4 @@
-import forEach from 'lodash/forEach'
+import { forEach } from 'lodash'
 
 export default function setEmptyAttributes(node) {
   if (!node.attributes) {

--- a/packages/mjml-parser-xml/src/index.js
+++ b/packages/mjml-parser-xml/src/index.js
@@ -1,13 +1,9 @@
 import htmlparser from 'htmlparser2'
 
-import isObject from 'lodash/isObject'
-import findLastIndex from 'lodash/findLastIndex'
-import find from 'lodash/find'
+import { isObject, findLastIndex, find } from 'lodash'
+import { filter, map, flow } from 'lodash/fp'
 import path from 'path'
 import fs from 'fs'
-import filter from 'lodash/fp/filter'
-import map from 'lodash/fp/map'
-import flow from 'lodash/fp/flow'
 
 import cleanNode from './helpers/cleanNode'
 import convertBooleansOnAttrs from './helpers/convertBooleansOnAttrs'
@@ -181,7 +177,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
 
         if (name === 'mj-include') {
           if (ignoreIncludes) return
-          
+
           inInclude = true
           handleInclude(decodeURIComponent(attrs.path), line)
           return

--- a/packages/mjml-validator/src/rules/validAttributes.js
+++ b/packages/mjml-validator/src/rules/validAttributes.js
@@ -1,7 +1,4 @@
-import concat from 'lodash/concat'
-import keys from 'lodash/keys'
-import includes from 'lodash/includes'
-import filter from 'lodash/filter'
+import { concat, keys, includes, filter } from 'lodash'
 
 import ruleError from './ruleError'
 

--- a/packages/mjml-validator/src/rules/validChildren.js
+++ b/packages/mjml-validator/src/rules/validChildren.js
@@ -1,6 +1,4 @@
-import filter from 'lodash/filter'
-import includes from 'lodash/includes'
-import keys from 'lodash/keys'
+import { filter, includes, keys } from 'lodash'
 
 import dependencies from '../dependencies'
 import ruleError from './ruleError'

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,7 +168,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0-beta.49", "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -242,6 +242,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -765,12 +770,12 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
-  integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
+"@babel/types@^7.0.0-beta.49", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
+  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
   dependencies:
-    esutils "^2.0.2"
+    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -1996,6 +2001,17 @@ babel-plugin-dynamic-import-node@^2.3.0:
   integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   dependencies:
     object.assign "^4.1.0"
+
+babel-plugin-lodash@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
@@ -4892,7 +4908,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6264,6 +6280,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Lodash is very big project. To not import everything we have to use
direct imports like `lodash/map`. Though it's hard to maintain such
imports in a big project. We need either linting or automatical
conversion to the right format.

In this diff I added babel plugin to solve the problem and converted all
direct imports to named ones for consistency.