### PR TITLE
Add doc for mjml-qr-code community component

### DIFF
--- a/doc/config.json
+++ b/doc/config.json
@@ -32,6 +32,7 @@
   "mjml/packages/mjml-wrapper/README.md",
   "mjml/doc/community-components.md",
   "mjml/doc/mjml-chart.md",
+  "mjml/doc/mjml-qr-code.md",
   "mjml/packages/mjml-validator/README.md",
   "mjml/doc/create.md",
   "mjml/doc/using_mjml_in_json.md",

--- a/doc/mjml-qr-code.md
+++ b/doc/mjml-qr-code.md
@@ -1,0 +1,10 @@
+## mj-qr-code
+
+This component displays QR codes in your email.  It's available on [Github](https://github.com/typpo/mjml-qr-code) and [NPM](https://www.npmjs.com/package/mjml-qr-code).
+
+By default, mj-qr-code uses the open-source QuickChart [QR code API](https://quickchart.io/).
+
+<p align="center">
+  <img src="https://quickchart.io/qr?text=mjml is easy!" alt="mj-qr-code demo" />
+</p>
+


### PR DESCRIPTION
This mjml component allows the user to send QR codes in email:
 - Github: https://github.com/typpo/mjml-qr-code
 - npm: https://www.npmjs.com/package/mjml-qr-code

QR codes in email are useful for event ticketing. coupons, etc.  

The component uses the [QuickChart](https://github.com/typpo/quickchart) QR code renderer, which is open-source and can be self-hosted.  It supports a `host` attribute so users can point to a custom renderer if desired.

Per discussion on MJML slack, I'm opening this pull request to document it as a community component.