### PR TITLE
fix #1834 #1928 Add comment about mj-column widths exceeding mj-section width

### DIFF
--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -3,6 +3,23 @@
 Columns enable you to horizontally organize the content within your sections. They must be located under `mj-section` tags in order to be considered by the engine.
 To be responsive, columns are expressed in terms of percentage.
 
+<aside class="notice">
+  Use caution with `width` attributes on `mj-column`.
+  It's okay if the sum of `mj-column` widths is
+      as much as the `mj-section` width.
+  Two columns of 50% are fine.
+  (The sum equals 100%.
+  Sums less than that are okay, too.)
+  However, if that sum exceeds the `mj-section` width,
+      do thorough testing, especially on desktop clients.
+  Three columns, two of 50% plus one of any percentage or
+      any fixed width could cause poor rendering.
+  (The first two columns use the full width.
+  The third causes need for more.)
+  It's best to avoid `width` sums greater than
+      `mj-section` width (either 100% or pixel width).
+</aside>
+
 Every single column has to contain something because they are responsive containers, and will be vertically stacked on a mobile view. Any standard component, or component that you have defined and registered, can be placed within a column – except `mj-column` or `mj-section` elements.
 
 ```xml

--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -4,20 +4,8 @@ Columns enable you to horizontally organize the content within your sections. Th
 To be responsive, columns are expressed in terms of percentage.
 
 <aside class="notice">
-  Use caution with `width` attributes on `mj-column`.
-  It's okay if the sum of `mj-column` widths is
-      as much as the `mj-section` width.
-  Two columns of 50% are fine.
-  (The sum equals 100%.
-  Sums less than that are okay, too.)
-  However, if that sum exceeds the `mj-section` width,
-      do thorough testing, especially on desktop clients.
-  Three columns, two of 50% plus one of any percentage or
-      any fixed width could cause poor rendering.
-  (The first two columns use the full width.
-  The third causes need for more.)
-  It's best to avoid `width` sums greater than
-      `mj-section` width (either 100% or pixel width).
+  The sum of columns in a section cannot be greater than
+      the width of the parent `mj-section` (or 100%).
 </aside>
 
 Every single column has to contain something because they are responsive containers, and will be vertically stacked on a mobile view. Any standard component, or component that you have defined and registered, can be placed within a column – except `mj-column` or `mj-section` elements.


### PR DESCRIPTION
**Fixes**

- Issue #1834. (I thought I'd put a PR on this one long ago. I was mistaken.)
- Issue #1928. This describes the same issue, though it is already closed. 

**Describe the bug**

Our documentation doesn't include a warning about specifying `mj-column` `width` attributes adding to more than 100% or equivalent pixel width of the enclosing `mj-section`. We see related questions on Slack periodically.

In Issue #1834, I document a suggestion from Nico about adding such a comment.

**To Reproduce**

Observe https://mjml.io/documentation/#mjml-column.

**Expected behavior**

Our documentation would better help our user base by including a short comment about `mj-column` `width` attributes adding up to wider than the enclosing `mj-section`.

**Included**

A new comment for our documentation in mjml/packages/mjml-column/README.com. That file only.

No changes to any JavaScript files.