### PR TITLE
Enables the mjml renderer to receive a userContext object that is available to all components on rendering

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -35,12 +35,14 @@ class Component {
       context = {},
       props = {},
       globalAttributes = {},
+      userContext,
     } = initialDatas
 
     this.props = {
       ...props,
       children,
       content,
+      userContext,
     }
 
     this.attributes = formatAttributes(
@@ -63,7 +65,9 @@ class Component {
   getAttribute(name) {
     return this.attributes[name]
   }
-
+  getUserContent() {
+    return this.props.userContext
+  }
   getContent() {
     return this.props.content.trim()
   }
@@ -202,6 +206,7 @@ export class BodyComponent extends Component {
       const component = initComponent({
         name: children.tagName,
         initialDatas: {
+          userContext: this.props.userContext,
           ...children,
           attributes: {
             ...attributes,
@@ -243,6 +248,7 @@ export class HeadComponent extends Component {
         name: children.tagName,
         initialDatas: {
           ...children,
+          userContext: this.props.userContext,
           context: this.getChildContext(),
         },
       })

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -43,6 +43,7 @@ class ValidationError extends Error {
 export default function mjml2html(mjml, options = {}) {
   let content = ''
   let errors = []
+  const { userContext } = options
 
   if (typeof options.skeleton === 'string') {
     /* eslint-disable global-require */
@@ -181,6 +182,7 @@ export default function mjml2html(mjml, options = {}) {
       initialDatas: {
         ...parseMJML(node),
         context,
+        userContext,
       },
     })
 


### PR DESCRIPTION
**Enables the mjml renderer to receive a userContext object that is available to all components on rendering**

We have some components that depend on user data when transforming the MJML code to HTML. Until now, we were using a global variable for context related things, but this can get complicated as we scale up the number of mjml2html concurrent executions.

Usage example:
```
const html = mjml2html(mjmlContent, {
        userContext: { data },
}).html;
```

Inside custom components we can fetch it by using:

```
export default class PAuthQrCode extends BodyComponent {
    render() {
       const context = this.userContext;
       const href = context.data.href;

       return this.renderMJML(`
      <mj-image-customized css-class="logo" align="center" width="175px" height="auto" padding="0" src="${href}?qrcode.png" />
    `);

    }
}

```