### PR TITLE
fix #1948 substitute a better word; documentation only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you're looking for MJML 3.3.X check [this branch](https://github.com/mjmlio/m
 
 # Introduction
 
-`MJML` is a markup language created by [Mailjet](https://www.mailjet.com/) and designed to reduce the pain of coding a responsive email. Its semantic syntax makes it easy and straightforward while its rich standard components library fastens your development time and lightens your email codebase. MJML’s open-source engine takes care of translating the `MJML` you wrote into responsive HTML.
+`MJML` is a markup language created by [Mailjet](https://www.mailjet.com/) and designed to reduce the pain of coding a responsive email. Its semantic syntax makes the language easy and straightforward while its rich standard components library shortens your development time and lightens your email codebase. MJML’s open-source engine takes care of translating the `MJML` you wrote into responsive HTML.
 
 <p align="center">
   <a href="https://mjml.io" target="_blank">


### PR DESCRIPTION
In the top-level README.md, change
  
>Its semantic syntax makes it easy and straightforward while
>its rich standard components library fastens your development time and
>lightens your email codebase.

 to

>Its semantic syntax makes the language easy and straightforward while
>its rich standard components library reduces your development time and
>lightens your email codebase.

No change to any JavaScript file.