### PR TITLE
chore: include directory for monorepo packages

### DIFF
--- a/packages/mjml-accordion/package.json
+++ b/packages/mjml-accordion/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-accordion"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-body/package.json
+++ b/packages/mjml-body/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-body"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-button/package.json
+++ b/packages/mjml-button/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-button"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-carousel/package.json
+++ b/packages/mjml-carousel/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-carousel"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-cli/package.json
+++ b/packages/mjml-cli/package.json
@@ -12,7 +12,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-cli"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-column/package.json
+++ b/packages/mjml-column/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-column"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-core/package.json
+++ b/packages/mjml-core/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-core"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-divider/package.json
+++ b/packages/mjml-divider/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-divider"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-group/package.json
+++ b/packages/mjml-group/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-group"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-attributes/package.json
+++ b/packages/mjml-head-attributes/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-attributes"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-breakpoint/package.json
+++ b/packages/mjml-head-breakpoint/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-breakpoint"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-font/package.json
+++ b/packages/mjml-head-font/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-font"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-html-attributes/package.json
+++ b/packages/mjml-head-html-attributes/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-html-attributes"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-preview/package.json
+++ b/packages/mjml-head-preview/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-preview"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-style/package.json
+++ b/packages/mjml-head-style/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-style"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head-title/package.json
+++ b/packages/mjml-head-title/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head-title"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-head/package.json
+++ b/packages/mjml-head/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-head"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-hero/package.json
+++ b/packages/mjml-hero/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-hero"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-image/package.json
+++ b/packages/mjml-image/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-image"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-migrate/package.json
+++ b/packages/mjml-migrate/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-migrate"
   },
   "author": "Nicolas Garnier",
   "license": "MIT",

--- a/packages/mjml-navbar/package.json
+++ b/packages/mjml-navbar/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-navbar"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-parser-xml/package.json
+++ b/packages/mjml-parser-xml/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-parser-xml"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-raw/package.json
+++ b/packages/mjml-raw/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-raw"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-section/package.json
+++ b/packages/mjml-section/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-section"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-social/package.json
+++ b/packages/mjml-social/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-social"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-spacer/package.json
+++ b/packages/mjml-spacer/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-spacer"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-table/package.json
+++ b/packages/mjml-table/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-table"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-text/package.json
+++ b/packages/mjml-text/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-text"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-validator/package.json
+++ b/packages/mjml-validator/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-validator"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml-wrapper/package.json
+++ b/packages/mjml-wrapper/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml-wrapper"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -12,7 +12,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mjmlio/mjml.git"
+    "url": "git+https://github.com/mjmlio/mjml.git",
+    "directory": "packages/mjml"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
`npm` allows to include a `directory` property for monorepo package
that some tools use to identify package location

https://docs.npmjs.com/files/package.json#repository

<details>
<summary>a meme</summary>

![image](https://user-images.githubusercontent.com/1881266/85897698-868cab80-b803-11ea-8284-b2020549cf69.png)
</details>
