### PR TITLE
fix conditional comment for meta tag in skeleton

### DIFF
--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -30,7 +30,7 @@ export default function skeleton(options) {
         <title>
           ${title}
         </title>
-        <!--[if !mso]><!-- -->
+        <!--[if !mso]><!-->
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <!--<![endif]-->
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
`<!--[if !mso]><!-- -->` will be parsed as a comment with a text content of `[if !mso]><!-- `

This PR changes the conditional comment in the skeleton to matches the other instances of conditional outlook tags in conditionalTag.js 

https://github.com/mjmlio/mjml/blob/604a9f2d2c19a224590814615fda8666fe1fd4e4/packages/mjml-core/src/helpers/conditionalTag.js#L4-L5