### PR TITLE
fix_1995-docs-only; remove MJML3 sentence from docs for mj-text

### DIFF
--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -25,7 +25,7 @@ This tag allows you to display text in your email.
 </p>
 
 <aside class="notice">
-  `MjText` can contain any HTML tag with any attributes. Don't forget to encode special characters to avoid unexpected behaviour from MJML's parser
+  `mj-text` elements can contain any HTML tag with any attributes.
 </aside>
 
  attribute                    | unit          | description                                 | default value


### PR DESCRIPTION
[Replaces PR #1996 and has contents identical to the intent for it. The branch names are different only in the punctuation at position four. This one has an underscore; ignore or delete the one with a dash.]

The docs for mj-text include an &lt;aside> with the sentence, "Don't forget to encode special characters to avoid unexpected behaviour from MJML's parser".

The sentence is a left-over from MJML3. It does not apply to MJML4.

This deletes the sentence. It's in _packages/mjml-text/README.md_.

Documentation only. No JavaScript files.

Fixes Issue #1995.