### PR TITLE
remove_MJML3-line-in-mj-include-docs_docs-only

### DIFF
--- a/doc/components_2.md
+++ b/doc/components_2.md
@@ -1,6 +1,7 @@
 ## mj-include
 
-The `mjml-core` package allows you to include external `mjml` files to build your email template.
+The `mjml-core` package allows you to include external `mjml` files
+  to build your email template.
 
 ```xml
 <!-- header.mjml -->
@@ -12,7 +13,7 @@ The `mjml-core` package allows you to include external `mjml` files to build you
 ```
 
 You can wrap your external mjml files inside the default `mjml > mj-body`
-tags to make it easier to preview outside the main template
+  tags to make it easier to preview outside the main template.
 
 
 ```xml
@@ -24,8 +25,5 @@ tags to make it easier to preview outside the main template
 </mjml>
 ```
 
-The `MJML` engine will then replace your included files before starting the rendering process
-
-<aside class="notice">
-Note that the file must be a file with a `.mjml` extension
-</aside>
+The `MJML` engine will then replace your included files before starting
+  the rendering process.


### PR DESCRIPTION
[Replaces PR #1999 and has contents identical to the intent for it. The branch names are different only in the punctuation at position seven. This one has an underscore; ignore or delete the one with a dash.]

The <mj-includes> docs include an aside:
> Note that the file must be a file with a `.mjml` extension

1. I recall past discussion indicating that applied only to MJML3.
2. I checked using an include file named only "include". MJML brought it into the main file without error.

The aside is in MJML/doc/components2.md.

This deletes the subject aside.

No changes to any JavaScript file. No associated Issue.