### PR TITLE
feat: also return the mjml json structure

### DIFF
--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -364,6 +364,7 @@ export default function mjml2html(mjml, options = {}) {
 
   return {
     html: content,
+    json: mjml,
     errors,
   }
 }


### PR DESCRIPTION
I know there is the `mjml2json` package out there, but it is a bit outdated (mjml 3) and `mjml-core` basically already does the same thing as far as I can tell.

The only downside perhaps is that this includes properties such as `absoluteFilePath` which we could omit, but I just wanted to gather thoughts on this PR first.