### PR TITLE
mj-column_inner-border_docs-only

### DIFF
--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -42,19 +42,19 @@ Every single column has to contain something because they are responsive contain
 attribute           | unit        | description                    | default attributes
 --------------------|-------------|--------------------------------|--------------------------------------
 background-color    | color       | background color for a column  | n/a
-inner-background-color | color    | requires: a padding, inner background color for column | n/a
+inner-background-color | color    | inner background color for column; requires a padding | n/a
 border              | string      | css border format              | none
 border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
 border-radius       | percent/px  | border radius                  | n/a
-inner-border        | string      | css border format              | n/a
-inner-border-bottom       | string      | css border format ; requires a padding | n/a
-inner-border-left         | string      | css border format ; requires a padding | n/a
-inner-border-right        | string      | css border format ; requires a padding | n/a
-inner-border-top          | string      | css border format ; requires a padding | n/a
-inner-border-radius       | percent/px  | border radius ; requires a padding     | n/a
+inner-border              | string      | css border format; requires a padding | n/a
+inner-border-bottom       | string      | css border format; requires a padding | n/a
+inner-border-left         | string      | css border format; requires a padding | n/a
+inner-border-right        | string      | css border format; requires a padding | n/a
+inner-border-top          | string      | css border format; requires a padding | n/a
+inner-border-radius       | percent/px  | border radius; requires a padding     | n/a
 width               | percent/px  | column width                   | (100 / number of non-raw elements in section)%
 vertical-align      | string      | middle/top/bottom              | top
 padding             | px          | supports up to 4 parameters    | n/a

--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -42,19 +42,19 @@ Every single column has to contain something because they are responsive contain
 attribute           | unit        | description                    | default attributes
 --------------------|-------------|--------------------------------|--------------------------------------
 background-color    | color       | background color for a column  | n/a
-inner-background-color | color    | inner background color for column; requires a padding | n/a
+inner-background-color | color    | requires: a padding, inner background color for column | n/a
 border              | string      | css border format              | none
 border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
 border-radius       | percent/px  | border radius                  | n/a
-inner-border              | string      | css border format; requires a padding | n/a
-inner-border-bottom       | string      | css border format; requires a padding | n/a
-inner-border-left         | string      | css border format; requires a padding | n/a
-inner-border-right        | string      | css border format; requires a padding | n/a
-inner-border-top          | string      | css border format; requires a padding | n/a
-inner-border-radius       | percent/px  | border radius; requires a padding     | n/a
+inner-border        | string      | css border format              | n/a
+inner-border-bottom       | string      | css border format ; requires a padding | n/a
+inner-border-left         | string      | css border format ; requires a padding | n/a
+inner-border-right        | string      | css border format ; requires a padding | n/a
+inner-border-top          | string      | css border format ; requires a padding | n/a
+inner-border-radius       | percent/px  | border radius ; requires a padding     | n/a
 width               | percent/px  | column width                   | (100 / number of non-raw elements in section)%
 vertical-align      | string      | middle/top/bottom              | top
 padding             | px          | supports up to 4 parameters    | n/a


### PR DESCRIPTION
mj-column_inner-border_docs-only

file packages/mjml-column/README.md only

Started as a means to add "requires a padding" in the attribute table to mj-column > inner-border (which is the only inner-border-x attribute lacking it).

As long as I was in the table, I found some minor formatting issues to improve.

Changed all the above.

Docs only. No JavaScript files.