### PR TITLE
Fix validate command to use the default base directory

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -193,7 +193,11 @@ export default async () => {
           compiled = { html: migrate(i.mjml, { beautify: true }) }
           break
         case 'v': // eslint-disable-next-line no-case-declarations
-          const mjmlJson = MJMLParser(i.mjml, { components })
+          const mjmlJson = MJMLParser(i.mjml, {
+            components,
+            filePath: filePath || i.file,
+            actualPath: i.file,
+          })
           compiled = {
             errors: validate(mjmlJson, { components, initializeType }),
           }


### PR DESCRIPTION
This PR adds the same base directory used in the build command to the validator command.

Close: #1911 