### PR TITLE
Explain-mj-title_docs-only

### DIFF
--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -42,19 +42,19 @@ Every single column has to contain something because they are responsive contain
 attribute           | unit        | description                    | default attributes
 --------------------|-------------|--------------------------------|--------------------------------------
 background-color    | color       | background color for a column  | n/a
-inner-background-color | color    | requires: a padding, inner background color for column | n/a
+inner-background-color | color    | inner background color for column; requires a padding | n/a
 border              | string      | css border format              | none
 border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
 border-radius       | percent/px  | border radius                  | n/a
-inner-border        | string      | css border format              | n/a
-inner-border-bottom       | string      | css border format ; requires a padding | n/a
-inner-border-left         | string      | css border format ; requires a padding | n/a
-inner-border-right        | string      | css border format ; requires a padding | n/a
-inner-border-top          | string      | css border format ; requires a padding | n/a
-inner-border-radius       | percent/px  | border radius ; requires a padding     | n/a
+inner-border              | string      | css border format; requires a padding | n/a
+inner-border-bottom       | string      | css border format; requires a padding | n/a
+inner-border-left         | string      | css border format; requires a padding | n/a
+inner-border-right        | string      | css border format; requires a padding | n/a
+inner-border-top          | string      | css border format; requires a padding | n/a
+inner-border-radius       | percent/px  | border radius; requires a padding     | n/a
 width               | percent/px  | column width                   | (100 / number of non-raw elements in section)%
 vertical-align      | string      | middle/top/bottom              | top
 padding             | px          | supports up to 4 parameters    | n/a

--- a/packages/mjml-column/README.md
+++ b/packages/mjml-column/README.md
@@ -42,19 +42,19 @@ Every single column has to contain something because they are responsive contain
 attribute           | unit        | description                    | default attributes
 --------------------|-------------|--------------------------------|--------------------------------------
 background-color    | color       | background color for a column  | n/a
-inner-background-color | color    | inner background color for column; requires a padding | n/a
+inner-background-color | color    | requires: a padding, inner background color for column | n/a
 border              | string      | css border format              | none
 border-bottom       | string      | css border format              | n/a
 border-left         | string      | css border format              | n/a
 border-right        | string      | css border format              | n/a
 border-top          | string      | css border format              | n/a
 border-radius       | percent/px  | border radius                  | n/a
-inner-border              | string      | css border format; requires a padding | n/a
-inner-border-bottom       | string      | css border format; requires a padding | n/a
-inner-border-left         | string      | css border format; requires a padding | n/a
-inner-border-right        | string      | css border format; requires a padding | n/a
-inner-border-top          | string      | css border format; requires a padding | n/a
-inner-border-radius       | percent/px  | border radius; requires a padding     | n/a
+inner-border        | string      | css border format              | n/a
+inner-border-bottom       | string      | css border format ; requires a padding | n/a
+inner-border-left         | string      | css border format ; requires a padding | n/a
+inner-border-right        | string      | css border format ; requires a padding | n/a
+inner-border-top          | string      | css border format ; requires a padding | n/a
+inner-border-radius       | percent/px  | border radius ; requires a padding     | n/a
 width               | percent/px  | column width                   | (100 / number of non-raw elements in section)%
 vertical-align      | string      | middle/top/bottom              | top
 padding             | px          | supports up to 4 parameters    | n/a

--- a/packages/mjml-head-title/README.md
+++ b/packages/mjml-head-title/README.md
@@ -1,6 +1,6 @@
 ## mj-title
 
-This tag allows you to set the title of an MJML document
+Defines the document's title that browsers show in the title bar or a page's tab.
 
  ```xml
 <mjml>


### PR DESCRIPTION
file: packages/mjml-head-title/README.md only

On May 29, at https://mjml.slack.com/archives/C12HESC2G/p1590763967164600, Piers Olenski asked the purpose of mj-title.

The same day, at https://mjml.slack.com/archives/DHSPC3WMS/p1590769167004200, iRyusa agreed a small change might be appropriate.

This changes one short sentence

> This tag allows you to set the title of an MJML document

to another

> Defines the document's title that browsers show in the title bar or a page's tab.

that provides slightly more information.

The content derives from https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title. They provide a little more detail. We don't need it.

Docs only. No JavaScript files.