### PR TITLE
mj_font_hosted_CSS_docs_only

### DIFF
--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -1,7 +1,10 @@
 ## mj-font
 
-This tag imports fonts for your use.
-The `href` attribute points to a hosted css file; that file points to the font file.
+This tag imports fonts.
+The tag has effect only if the template uses the font, too. 
+The `href` attribute points to a hosted css file; that file contains a `@font-face` declaration.
+Example: [https://fonts
+.googleapis.com/css?family=Raleway](https://fonts.googleapis.com/css?family=Raleway)
 Some font providers (as in our example code) host both the CSS and the font files.
 
  ```xml
@@ -28,11 +31,7 @@ Some font providers (as in our example code) host both the CSS and the font file
   </a>
 </p>
 
-<aside class="notice">
-  If you don't get a CSS file, model one on the "href" file in the example.
-</aside>
-
-attribute   | unit     | description                             | default value
-------------|----------|-----------------------------------------|---------------
-href        | string   | URL of a hosted CSS file for the font   | n/a
-name        | string   | name of the font                        | n/a
+attribute   | unit     | description                | default value
+------------|----------|----------------------------|---------------
+href        | string   | URL of a hosted CSS file   | n/a
+name        | string   | name of the font           | n/a

--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -5,7 +5,6 @@ The tag has effect only if the template uses the font, too.
 The `href` attribute points to a hosted css file; that file contains a `@font-face` declaration.
 Example: [https://fonts
 .googleapis.com/css?family=Raleway](https://fonts.googleapis.com/css?family=Raleway)
-Some font providers (as in our example code) host both the CSS and the font files.
 
  ```xml
  <mjml>

--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -1,11 +1,14 @@
 ## mj-font
 
-This tag allows you to import fonts if used in your MJML document
+This tag imports fonts for your use.
+The `href` attribute points to a hosted css file; that file points to the font file.
+Some font providers (as in our example code) host both the CSS and the font files.
 
  ```xml
  <mjml>
    <mj-head>
-     <mj-font name="Raleway" href="https://fonts.googleapis.com/css?family=Raleway" />
+     <mj-font name="Raleway"
+       href="https://fonts.googleapis.com/css?family=Raleway" />
    </mj-head>
    <mj-body>
      <mj-section>
@@ -25,9 +28,11 @@ This tag allows you to import fonts if used in your MJML document
   </a>
 </p>
 
+<aside class="notice">
+  If you don't get a CSS file, model one on the "href" file in the example.
+</aside>
 
-attribute            | unit          | description                    | default value
----------------------|---------------|--------------------------------|---------------
-href                 | string        | url of the font                | n/a
-name                 | string        | name of the font               | n/a
-
+attribute   | unit     | description                             | default value
+------------|----------|-----------------------------------------|---------------
+href        | string   | URL of a hosted CSS file for the font   | n/a
+name        | string   | name of the font                        | n/a


### PR DESCRIPTION
We can improve our mj-font documentation by informing our readers that they must point to a hosted CSS file in their href attribute.

On the #general Slack channel, we see confusion too often after developers point href to a ttf file, for example.

file: packages/mjml-head-font/README.md
no other; no JavaScript files