### PR TITLE
feat(mj-accordion-text): add new attributes

### DIFF
--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -121,6 +121,9 @@ color | n/a | text color | n/a
 css-class | string | class name, added to the root HTML element created | n/a
 font-family | n/a | font family | Ubuntu, Helvetica, Arial, sans-serif
 font-size | px | font size | 13px
+font-weight | number | text thickness | n/a
+letter-spacing | px,em | letter spacing | none
+line-height | px | space between the lines | 1
 padding | px | padding | 16px
 padding-bottom | px | padding bottom | n/a
 padding-left | px | padding left | n/a

--- a/packages/mjml-accordion/src/AccordionText.js
+++ b/packages/mjml-accordion/src/AccordionText.js
@@ -7,6 +7,9 @@ export default class MjAccordionText extends BodyComponent {
     'background-color': 'color',
     'font-size': 'unit(px)',
     'font-family': 'string',
+    'font-weight': 'string',
+    'letter-spacing': 'unitWithNegative(px,em)',
+    'line-height': 'unit(px,%,)',
     color: 'color',
     'padding-bottom': 'unit(px,%)',
     'padding-left': 'unit(px,%)',
@@ -17,6 +20,7 @@ export default class MjAccordionText extends BodyComponent {
 
   static defaultAttributes = {
     'font-size': '13px',
+    'line-height': '1',
     padding: '16px',
   }
 
@@ -26,6 +30,9 @@ export default class MjAccordionText extends BodyComponent {
         background: this.getAttribute('background-color'),
         'font-size': this.getAttribute('font-size'),
         'font-family': this.getAttribute('font-family'),
+        'font-weight': this.getAttribute('font-weight'),
+        'letter-spacing': this.getAttribute('letter-spacing'),
+        'line-height': this.getAttribute('line-height'),
         color: this.getAttribute('color'),
         'padding-bottom': this.getAttribute('padding-bottom'),
         'padding-left': this.getAttribute('padding-left'),


### PR DESCRIPTION
This PR adds the following attributes to the component `mj-accordion-text`

1. font-weight
2. letter-spacing
3. line-height

## Motivation
It would be nice if `mj-accordion-text` accepts the same attributes as `mj-text` does. 
I had to change the `font-weight` from the accordion content and I couldn't because `mj-accordion-text` does not accept it.