### PR TITLE
renderMJML supports sibling elements

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -72,6 +72,20 @@ class Component {
 
   renderMJML(mjml, options = {}) {
     if (typeof mjml === 'string') {
+      if (mjml.indexOf('<mjml>') === -1) {
+        // supports returning siblings elements from a custom component
+        const partialMjml = MJMLParser(`<mjml><mj-body>${mjml}</mj-body></mjml>`, {
+          ...options,
+          components,
+          ignoreIncludes: true,
+        })
+        const body = find(partialMjml.children, { tagName: 'mj-body' })
+
+        return body.children
+          .map(child => this.context.processing(child, this.context))
+          .join('')
+      }
+
       mjml = MJMLParser(mjml, {
         ...options,
         components,

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -72,25 +72,15 @@ class Component {
 
   renderMJML(mjml, options = {}) {
     if (typeof mjml === 'string') {
-      if (mjml.indexOf('<mjml>') === -1) {
-        // supports returning siblings elements from a custom component
-        const partialMjml = MJMLParser(`<mjml><mj-body>${mjml}</mj-body></mjml>`, {
-          ...options,
-          components,
-          ignoreIncludes: true,
-        })
-        const body = find(partialMjml.children, { tagName: 'mj-body' })
-
-        return body.children
-          .map(child => this.context.processing(child, this.context))
-          .join('')
-      }
-
-      mjml = MJMLParser(mjml, {
+      // supports returning siblings elements from a custom component
+      const partialMjml = MJMLParser(`<fragment>${mjml}</fragment>`, {
         ...options,
         components,
         ignoreIncludes: true,
       })
+      return partialMjml.children
+        .map(child => this.context.processing(child, this.context))
+        .join('')
     }
 
     return this.context.processing(mjml, this.context)


### PR DESCRIPTION
This PR adds support for returning sibling elements from a custom component. Based on slack conversation: https://mjml.slack.com/archives/C12HESC2G/p1601316349042200

I tried to add the functionality without breaking any of the other code paths.

I tested this with components that return 1, 2, or 8 sibling nodes.
However, the testing framework is difficult to work with and it seems like it would be a LOT of work to actually test this properly.

Let me know if there's anything else this PR needs 🥂 