### PR TITLE
Fix issue with stacking columns within mj-group in Gmail for IOS 

### DIFF
--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -76,10 +76,9 @@ export default function skeleton(options) {
         }
         ${headRaw.filter(negate(isNil)).join('\n')}
       </head>
-      <body${
-        backgroundColor === ''
-          ? ''
-          : ` style="background-color:${backgroundColor};"`
+      <body${backgroundColor === ''
+        ? ' style="word-spacing:normal"'
+        : ` style="word-spacing:normal;background-color:${backgroundColor};"`
       }>
         ${buildPreview(preview)}
         ${content}

--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -76,10 +76,7 @@ export default function skeleton(options) {
         }
         ${headRaw.filter(negate(isNil)).join('\n')}
       </head>
-      <body${backgroundColor === ''
-        ? ' style="word-spacing:normal"'
-        : ` style="word-spacing:normal;background-color:${backgroundColor};"`
-      }>
+      <body style="word-spacing:normal;${backgroundColor ? `background-color:${backgroundColor};` : ''}">
         ${buildPreview(preview)}
         ${content}
       </body>


### PR DESCRIPTION
This PR resolves the bug in Gmail on IOS where the `word-spacing: 1px` is added to the body causing the mj-group columns to stack. The issue is outlined here https://github.com/hteumeuleu/email-bugs/issues/80 and the suggested fix is provided by Mark Robbins.

Example MJML to reproduce issue:

```
<mjml>
  <mj-body>
    <mj-section>
      <mj-group>
        <mj-column>
          <mj-text font-size="13px" color="#000000">Text left</mj-text>
        </mj-column>
        <mj-column>
          <mj-text font-size="13px" color="#000000">Text right</mj-text>
        </mj-column>
      </mj-group>
    </mj-section>
  </mj-body>
</mjml>
```

Columns are stacking in IOS 14 on Gmail. The fix will ensure that the columns remain inline. 

Email on Acid link testing updated MJML https://app.emailonacid.com/app/acidtest/dl3EjaVeiHMeg4jQuqi7vci31erb7xGdGJa93CSOY0QZ6/list