### PR TITLE
Move js-beautify and html-minifier to cli

### DIFF
--- a/packages/mjml-cli/package.json
+++ b/packages/mjml-cli/package.json
@@ -28,6 +28,8 @@
     "@babel/runtime": "^7.8.7",
     "chokidar": "^3.0.0",
     "glob": "^7.1.1",
+    "html-minifier": "^3.5.3",
+    "js-beautify": "^1.6.14",
     "lodash": "^4.17.15",
     "mjml-core": "4.7.1",
     "mjml-migrate": "4.7.1",

--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -2,6 +2,8 @@ import path from 'path'
 import yargs from 'yargs'
 import { flow, pick, isNil, negate, pickBy } from 'lodash/fp'
 import { isArray, isEmpty, map, get } from 'lodash'
+import { html as htmlBeautify } from 'js-beautify'
+import { minify as htmlMinify } from 'html-minifier'
 
 import mjml2html, { components, initializeType } from 'mjml-core'
 import migrate from 'mjml-migrate'
@@ -202,12 +204,35 @@ export default async () => {
             errors: validate(mjmlJson, { components, initializeType }),
           }
           break
-        default:
+
+        default: {
+          const beautify = config.beautify && config.beautify !== 'false'
+          const minify = config.minify && config.minify !== 'false'
+          delete config.minify
+          delete config.beautify
           compiled = mjml2html(i.mjml, {
             ...config,
             filePath: filePath || i.file,
             actualPath: i.file,
           })
+          if (beautify) {
+            compiled = htmlBeautify(compiled, {
+              indent_size: 2,
+              wrap_attributes_indent_size: 2,
+              max_preserve_newline: 0,
+              preserve_newlines: false,
+            })
+          }
+          if (minify) {
+            compiled = htmlMinify(compiled, {
+              collapseWhitespace: true,
+              minifyCSS: false,
+              caseSensitive: true,
+              removeEmptyAttributes: true,
+              ...config.minifyOptions,
+            })
+          }
+        }
       }
 
       convertedStream.push({ ...i, compiled })

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -298,10 +298,8 @@ export default function mjml2html(mjml, options = {}) {
 
   content = processing(mjBody, bodyHelpers, applyAttributes)
 
-  if (minify && minify !== 'false') {
-    content = minifyOutlookConditionnals(content)
-  }
-  
+  content = minifyOutlookConditionnals(content)
+
   if (!isEmpty(globalDatas.htmlAttributes)) {
     const $ = cheerio.load(content, {
       xmlMode: true, // otherwise it may move contents that aren't in any tag
@@ -340,17 +338,24 @@ export default function mjml2html(mjml, options = {}) {
     })
   }
 
-  content =
-    beautify && beautify !== 'false'
-      ? htmlBeautify(content, {
-          indent_size: 2,
-          wrap_attributes_indent_size: 2,
-          max_preserve_newline: 0,
-          preserve_newlines: false,
-        })
-      : content
+  content = mergeOutlookConditionnals(content)
 
-  if (minify && minify !== 'false') {
+  if (beautify) {
+    console.warn(
+      '"beautify" option is deprecated in mjml-core and only available in mjml cli.',
+    )
+    content = htmlBeautify(content, {
+      indent_size: 2,
+      wrap_attributes_indent_size: 2,
+      max_preserve_newline: 0,
+      preserve_newlines: false,
+    })
+  }
+
+  if (minify) {
+    console.warn(
+      '"minify" option is deprecated in mjml-core and only available in mjml cli.',
+    )
     content = htmlMinify(content, {
       collapseWhitespace: true,
       minifyCSS: false,
@@ -359,8 +364,6 @@ export default function mjml2html(mjml, options = {}) {
       ...minifyOptions,
     })
   }
-
-  content = mergeOutlookConditionnals(content)
 
   return {
     html: content,


### PR DESCRIPTION
Ref https://github.com/mjmlio/mjml/issues/1947

- minify outlook conditionals unconditionally like merging
- moved js-beautify and html-minifier to cli
- deprecated "minify" and "beautify" options in mjml-core