### PR TITLE
Roadmap-is-open; docs only

### DIFF
--- a/doc/tooling.md
+++ b/doc/tooling.md
@@ -20,4 +20,4 @@ Gulp is a tool designed to help you automate and enhance your workflow. Our plug
 ## Contribute to the MJML ecosystem
 The MJML ecosystem is still young and we're also counting on your help to help us make it grow and provide its community with even more awesome tools, always aiming to making development with MJML an efficient and fun process!
 
-Getting involved is really easy and our [roadmap is open](https://github.com/mjmlio/mjml/projects/1). If you want to contribute, feel free to [open an issue](https://github.com/mjmlio/mjml/issues) or [submit a pull-request](https://github.com/mjmlio/mjml/pulls)!
+Getting involved is really easy. If you want to contribute, feel free to [open an issue](https://github.com/mjmlio/mjml/issues) or [submit a pull-request](https://github.com/mjmlio/mjml/pulls)!

--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -15,7 +15,6 @@ export default class MjSpacer extends BodyComponent {
     'padding-right': 'unit(px,%)',
     'padding-top': 'unit(px,%)',
     padding: 'unit(px,%){1,4}',
-    'vertical-align': 'enum(top,bottom,middle)',
     height: 'unit(px,%)',
   }
 

--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -15,6 +15,7 @@ export default class MjSpacer extends BodyComponent {
     'padding-right': 'unit(px,%)',
     'padding-top': 'unit(px,%)',
     padding: 'unit(px,%){1,4}',
+    'vertical-align': 'enum(top,bottom,middle)',
     height: 'unit(px,%)',
   }
 


### PR DESCRIPTION
roadmap-is-open
docs only

In doc/tooling.md, we have said the MJML roadmap is open at https://github.com/mjmlio/mjml/projects/1.

Perhaps that's one of the optional outreach tasks the project has no time to support.

It's blank. The last update was two years ago.

This deletes the reference to the roadmap.

file: doc/tooling.md
no other; no JavaScript files