### PR TITLE
Revamp validator

### DIFF
--- a/packages/mjml-cli/src/client.js
+++ b/packages/mjml-cli/src/client.js
@@ -7,7 +7,7 @@ import { minify as htmlMinify } from 'html-minifier'
 
 import mjml2html, { components, initializeType } from 'mjml-core'
 import migrate from 'mjml-migrate'
-import validate from 'mjml-validator'
+import validate, { dependencies } from 'mjml-validator'
 import MJMLParser from 'mjml-parser-xml'
 
 import { version as coreVersion } from 'mjml-core/package.json'
@@ -201,7 +201,7 @@ export default async () => {
             actualPath: i.file,
           })
           compiled = {
-            errors: validate(mjmlJson, { components, initializeType }),
+            errors: validate(mjmlJson, { dependencies, components, initializeType }),
           }
           break
 

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -16,7 +16,7 @@ import { minify as htmlMinify } from 'html-minifier'
 import cheerio from 'cheerio'
 
 import MJMLParser from 'mjml-parser-xml'
-import MJMLValidator from 'mjml-validator'
+import MJMLValidator, { dependencies } from 'mjml-validator'
 import { handleMjml3 } from 'mjml-migrate'
 
 import components, { initComponent, registerComponent } from './components'
@@ -142,6 +142,7 @@ export default function mjml2html(mjml, options = {}) {
 
   const validatorOptions = {
     components,
+    dependencies,
     initializeType,
   }
 

--- a/packages/mjml-validator/package.json
+++ b/packages/mjml-validator/package.json
@@ -21,9 +21,7 @@
     "build": "babel src --out-dir lib --root-mode upward"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.7",
-    "lodash": "^4.17.15",
-    "warning": "^4.0.3"
+    "@babel/runtime": "^7.8.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/mjml-validator/src/MJMLRulesCollection.js
+++ b/packages/mjml-validator/src/MJMLRulesCollection.js
@@ -1,13 +1,20 @@
-import warning from 'warning'
-import { mapKeys } from 'lodash'
+import validAttributes from './rules/validAttributes'
+import validChildren from './rules/validChildren'
+import validTag from './rules/validTag'
+import validTypes from './rules/validTypes'
+import errorAttr from './rules/errorAttr'
 
-import * as rules from './rules'
-
-const MJMLRulesCollection = {}
+const MJMLRulesCollection = {
+  validAttributes,
+  validChildren,
+  validTag,
+  validTypes,
+  errorAttr,
+}
 
 export function registerRule(rule, name) {
   if (typeof rule !== 'function') {
-    return warning(false, 'Your rule must be a function')
+    return console.error('Your rule must be a function')
   }
 
   if (name) {
@@ -18,7 +25,5 @@ export function registerRule(rule, name) {
 
   return true
 }
-
-mapKeys(rules, (func, name) => registerRule(func, name))
 
 export default MJMLRulesCollection

--- a/packages/mjml-validator/src/dependencies.js
+++ b/packages/mjml-validator/src/dependencies.js
@@ -1,6 +1,6 @@
 export const assignDependencies = (target, ...sources) => {
   for (const source of sources) {
-    for (const tag of source) {
+    for (const tag of Object.keys(source)) {
       const list = []
       if (target[tag]) {
         list.push(...target[tag])

--- a/packages/mjml-validator/src/dependencies.js
+++ b/packages/mjml-validator/src/dependencies.js
@@ -1,25 +1,23 @@
-export const mergeDependencies = (left, right) => {
-  const allTags = Array.from(
-    new Set([...Object.keys(left), ...Object.keys(right)]),
-  )
-  const newDependencies = {}
-  for (const tag of allTags) {
-    const list = []
-    if (left[tag]) {
-      list.push(...left[tag])
+export const assignDependencies = (target, ...sources) => {
+  for (const source of sources) {
+    for (const tag of source) {
+      const list = []
+      if (target[tag]) {
+        list.push(...target[tag])
+      }
+      if (source[tag]) {
+        list.push(...source[tag])
+      }
+      target[tag] = Array.from(new Set(list))
     }
-    if (right[tag]) {
-      list.push(...right[tag])
-    }
-    newDependencies[tag] = Array.from(new Set(list))
   }
-  return newDependencies
+  return target
 }
 
 const dependencies = {}
 
 export const registerDependencies = (dep) => {
-  dependencies = mergeDependencies(dependencies, dep)
+  assignDependencies(dependencies, dep)
 }
 
 export default dependencies

--- a/packages/mjml-validator/src/dependencies.js
+++ b/packages/mjml-validator/src/dependencies.js
@@ -1,15 +1,25 @@
-import { mergeWith, isArray } from 'lodash'
-
-// eslint-disable-next-line consistent-return
-function mergeArrays(objValue, srcValue) {
-  if (isArray(objValue) && isArray(srcValue)) {
-    return objValue.concat(srcValue)
+export const mergeDependencies = (left, right) => {
+  const allTags = Array.from(
+    new Set([...Object.keys(left), ...Object.keys(right)]),
+  )
+  const newDependencies = {}
+  for (const tag of allTags) {
+    const list = []
+    if (left[tag]) {
+      list.push(...left[tag])
+    }
+    if (right[tag]) {
+      list.push(...right[tag])
+    }
+    newDependencies[tag] = Array.from(new Set(list))
   }
+  return newDependencies
 }
 
 const dependencies = {}
 
-export const registerDependencies = (dep) =>
-  mergeWith(dependencies, dep, mergeArrays)
+export const registerDependencies = (dep) => {
+  dependencies = mergeDependencies(dependencies, dep)
+}
 
 export default dependencies

--- a/packages/mjml-validator/src/index.js
+++ b/packages/mjml-validator/src/index.js
@@ -25,13 +25,16 @@ export default function MJMLValidator(element, options = {}) {
 
   if (!skipElements.includes(tagName)) {
     for (const rule of Object.values(rulesCollection)) {
-      errors.push(
-        ...rule(element, {
-          dependencies,
-          skipElements,
-          ...options,
-        }),
-      )
+      const ruleError = rule(element, {
+        dependencies,
+        skipElements,
+        ...options,
+      })
+      if (Array.isArray(ruleError)) {
+        errors.push(...ruleError)
+      } else if (ruleError) {
+        errors.push(ruleError)
+      }
     }
   }
 

--- a/packages/mjml-validator/src/index.js
+++ b/packages/mjml-validator/src/index.js
@@ -1,40 +1,42 @@
-import { flatten, concat, filter, includes, values } from 'lodash'
-
 import ruleError from './rules/ruleError'
 import rulesCollection, { registerRule } from './MJMLRulesCollection'
+import dependencies, { registerDependencies } from './dependencies'
 
 const SKIP_ELEMENTS = ['mjml']
 
 export const formatValidationError = ruleError
 
 export { rulesCollection, registerRule }
-export { default as dependencies, registerDependencies } from './dependencies'
+
+export { dependencies, registerDependencies, mergeDependencies }
 
 export default function MJMLValidator(element, options = {}) {
   const { children, tagName } = element
-  let errors
+  const errors = []
 
   const skipElements = options.skipElements || SKIP_ELEMENTS
 
-  if (!includes(skipElements, tagName)) {
-    errors = flatten(
-      concat(
-        errors,
-        ...values(rulesCollection).map((rule) =>
-          rule(element, {
-            skipElements,
-            ...options,
-          }),
-        ),
-      ),
-    )
+  if (options.dependencies == null) {
+    console.warn('"dependencies" option should be provided to mjml validator')
+  }
+
+  if (!skipElements.includes(tagName)) {
+    for (const rule of Object.values(rulesCollection)) {
+      errors.push(
+        ...rule(element, {
+          dependencies,
+          skipElements,
+          ...options,
+        }),
+      )
+    }
   }
 
   if (children && children.length > 0) {
-    errors = flatten(
-      concat(errors, ...children.map((child) => MJMLValidator(child, options))),
-    )
+    for (const child of children) {
+      errors.push(...MJMLValidator(child, options))
+    }
   }
 
-  return filter(errors)
+  return errors
 }

--- a/packages/mjml-validator/src/index.js
+++ b/packages/mjml-validator/src/index.js
@@ -1,6 +1,9 @@
 import ruleError from './rules/ruleError'
 import rulesCollection, { registerRule } from './MJMLRulesCollection'
-import dependencies, { registerDependencies } from './dependencies'
+import dependencies, {
+  registerDependencies,
+  mergeDependencies,
+} from './dependencies'
 
 const SKIP_ELEMENTS = ['mjml']
 

--- a/packages/mjml-validator/src/index.js
+++ b/packages/mjml-validator/src/index.js
@@ -2,7 +2,7 @@ import ruleError from './rules/ruleError'
 import rulesCollection, { registerRule } from './MJMLRulesCollection'
 import dependencies, {
   registerDependencies,
-  mergeDependencies,
+  assignDependencies,
 } from './dependencies'
 
 const SKIP_ELEMENTS = ['mjml']
@@ -11,7 +11,7 @@ export const formatValidationError = ruleError
 
 export { rulesCollection, registerRule }
 
-export { dependencies, registerDependencies, mergeDependencies }
+export { dependencies, registerDependencies, assignDependencies }
 
 export default function MJMLValidator(element, options = {}) {
   const { children, tagName } = element

--- a/packages/mjml-validator/src/rules/index.js
+++ b/packages/mjml-validator/src/rules/index.js
@@ -1,5 +1,0 @@
-export { default as validAttributes } from './validAttributes'
-export { default as validChildren } from './validChildren'
-export { default as validTag } from './validTag'
-export { default as validTypes } from './validTypes'
-export { default as errorAttr } from './errorAttr'

--- a/packages/mjml-validator/src/rules/validAttributes.js
+++ b/packages/mjml-validator/src/rules/validAttributes.js
@@ -12,7 +12,7 @@ export default function validateAttribute(element, { components }) {
   }
 
   const availableAttributes = [
-    ...Object.keys(Component.allowedAttributes),
+    ...Object.keys(Component.allowedAttributes || {}),
     ...WHITELIST,
   ]
   const unknownAttributes = Object.keys(attributes).filter(

--- a/packages/mjml-validator/src/rules/validAttributes.js
+++ b/packages/mjml-validator/src/rules/validAttributes.js
@@ -1,5 +1,3 @@
-import { concat, keys, includes, filter } from 'lodash'
-
 import ruleError from './ruleError'
 
 const WHITELIST = ['mj-class', 'css-class']
@@ -13,13 +11,12 @@ export default function validateAttribute(element, { components }) {
     return null
   }
 
-  const availableAttributes = concat(
-    keys(Component.allowedAttributes),
-    WHITELIST,
-  )
-  const unknownAttributes = filter(
-    keys(attributes),
-    (attribute) => !includes(availableAttributes, attribute),
+  const availableAttributes = [
+    ...Object.keys(Component.allowedAttributes),
+    ...WHITELIST,
+  ]
+  const unknownAttributes = Object.keys(attributes).filter(
+    (attribute) => !availableAttributes.includes(attribute),
   )
 
   if (unknownAttributes.length === 0) {

--- a/packages/mjml-validator/src/rules/validChildren.js
+++ b/packages/mjml-validator/src/rules/validChildren.js
@@ -19,33 +19,32 @@ export default function validChildren(
     const ChildComponent = components[childTagName]
     const parentDependencies = dependencies[tagName] || []
 
-    if (
+    const childIsValid =
       !ChildComponent ||
       skipElements.includes(childTagName) ||
       parentDependencies.includes(childTagName) ||
       parentDependencies.some(
         (dep) => dep instanceof RegExp && dep.test(childTagName),
       )
-    ) {
-      continue
-    }
 
-    const allowedDependencies = Object.keys(dependencies).filter(
-      (key) =>
-        dependencies[key].includes(childTagName) ||
-        dependencies[key].some(
-          (dep) => dep instanceof RegExp && dep.test(childTagName),
+    if (childIsValid === false) {
+      const allowedDependencies = Object.keys(dependencies).filter(
+        (key) =>
+          dependencies[key].includes(childTagName) ||
+          dependencies[key].some(
+            (dep) => dep instanceof RegExp && dep.test(childTagName),
+          ),
+      )
+
+      errors.push(
+        ruleError(
+          `${childTagName} cannot be used inside ${tagName}, only inside: ${allowedDependencies.join(
+            ', ',
+          )}`,
+          child,
         ),
-    )
-
-    errors.push(
-      ruleError(
-        `${childTagName} cannot be used inside ${tagName}, only inside: ${allowedDependencies.join(
-          ', ',
-        )}`,
-        child,
-      ),
-    )
+      )
+    }
   }
 
   return errors

--- a/packages/mjml-validator/src/rules/validTag.js
+++ b/packages/mjml-validator/src/rules/validTag.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash'
 import ruleError from './ruleError'
 
 // Tags that have no associated components but are allowed even so
@@ -12,7 +11,7 @@ const componentLessTags = [
 export default function validateTag(element, { components }) {
   const { tagName } = element
 
-  if (includes(componentLessTags, tagName)) return null
+  if (componentLessTags.includes(tagName)) return null
 
   const Component = components[tagName]
 

--- a/packages/mjml-validator/src/rules/validTypes.js
+++ b/packages/mjml-validator/src/rules/validTypes.js
@@ -1,5 +1,3 @@
-import { compact, map } from 'lodash'
-
 import ruleError from './ruleError'
 
 export default function validateType(element, { components, initializeType }) {
@@ -11,16 +9,20 @@ export default function validateType(element, { components, initializeType }) {
     return null
   }
 
-  return compact(
-    map(attributes, (value, attr) => {
-      const attrType =
-        Component.allowedAttributes && Component.allowedAttributes[attr]
-      if (!attrType) return null // attribute not allowed
+  const errors = []
 
-      const TypeChecker = initializeType(attrType)
-      const result = new TypeChecker(value)
-      if (result.isValid()) return null
-      return ruleError(`Attribute ${attr} ${result.getErrorMessage()}`, element)
-    }),
-  )
+  for (const [attr, value] of Object.entries(attributes)) {
+    const attrType =
+      Component.allowedAttributes && Component.allowedAttributes[attr]
+    if (!attrType) continue // attribute not allowed
+
+    const TypeChecker = initializeType(attrType)
+    const result = new TypeChecker(value)
+    if (result.isValid()) continue
+    errors.push(
+      ruleError(`Attribute ${attr} ${result.getErrorMessage()}`, element),
+    )
+  }
+
+  return errors
 }

--- a/packages/mjml-validator/src/rules/validTypes.js
+++ b/packages/mjml-validator/src/rules/validTypes.js
@@ -14,14 +14,15 @@ export default function validateType(element, { components, initializeType }) {
   for (const [attr, value] of Object.entries(attributes)) {
     const attrType =
       Component.allowedAttributes && Component.allowedAttributes[attr]
-    if (!attrType) continue // attribute not allowed
-
-    const TypeChecker = initializeType(attrType)
-    const result = new TypeChecker(value)
-    if (result.isValid()) continue
-    errors.push(
-      ruleError(`Attribute ${attr} ${result.getErrorMessage()}`, element),
-    )
+    if (attrType) {
+      const TypeChecker = initializeType(attrType)
+      const result = new TypeChecker(value)
+      if (result.isValid() === false) {
+        errors.push(
+          ruleError(`Attribute ${attr} ${result.getErrorMessage()}`, element),
+        )
+      }
+    }
   }
 
   return errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -7168,13 +7168,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
-
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
- drop meaningful warning package
- statically define builtin rules (avoided iterating module namespace)
- drop lodash because builtin methods are good enough
- pass dependencies to rule options instead of importing in rule module
- implement assignDependencies utility based on dependencies structure
- fixed duplicating dependencies when registering multiple times
- require passing dependencies explicitly to get rid from side effects (warn for now)