### PR TITLE
Transpile lib for node 10

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     "semi": [ 2, "never" ],
     "no-mixed-operators": 0,
     "no-shadow": 0,
-    "no-param-reassign": 0
+    "no-param-reassign": 0,
+    "no-restricted-syntax": 0
   },
   "env": {
     "node": true

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: ['@babel/env'],
+  presets: [['@babel/env', { targets: { node: '10' } }]],
   plugins: [
     '@babel/proposal-class-properties',
     [


### PR DESCRIPTION
This change allows to not add helpers and regenerator for many features
which work in node and modern web.

Disabled syntax restriction in eslint to allow using for/of loops.