### PR TITLE
Add align attribute to divider

### DIFF
--- a/packages/mjml-divider/README.md
+++ b/packages/mjml-divider/README.md
@@ -20,17 +20,17 @@ Displays a horizontal divider that can be customized like a HTML border.
   </a>
 </p>
 
-attribute                   | unit        | description                    | default value
-----------------------------|-------------|--------------------------------|------------------------------
-border-color                | color       | divider color                  | #000000
-border-style                | string      | dashed/dotted/solid            | solid
-border-width                | px          | divider's border width         | 4px
-container-background-color  | color       | inner element background color | n/a
-css-class                   | string      | class name, added to the root HTML element created | n/a
-padding                     | px          | supports up to 4 parameters    | 10px 25px
-padding-bottom              | px          | bottom offset                  | n/a
-padding-left                | px          | left offset                    | n/a
-padding-right               | px          | right offset                   | n/a
-padding-top                 | px          | top offset                     | n/a
-width                       | px/percent  | divider width                  | 100%
-
+| attribute                  | unit               | description                                        | default value |
+| -------------------------- | ------------------ | -------------------------------------------------- | ------------- |
+| border-color               | color              | divider color                                      | #000000       |
+| border-style               | string             | dashed/dotted/solid                                | solid         |
+| border-width               | px                 | divider's border width                             | 4px           |
+| container-background-color | color              | inner element background color                     | n/a           |
+| css-class                  | string             | class name, added to the root HTML element created | n/a           |
+| padding                    | px                 | supports up to 4 parameters                        | 10px 25px     |
+| padding-bottom             | px                 | bottom offset                                      | n/a           |
+| padding-left               | px                 | left offset                                        | n/a           |
+| padding-right              | px                 | right offset                                       | n/a           |
+| padding-top                | px                 | top offset                                         | n/a           |
+| width                      | px/percent         | divider width                                      | 100%          |
+| align                      | left,center, right | alignment                                          | center        |

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -29,17 +29,18 @@ export default class MjDivider extends BodyComponent {
   }
 
   getStyles() {
+    let computeAlign = '0px auto'
+    if (this.getAttribute('align') === 'left') {
+      computeAlign = '0px'
+    } else if (this.getAttribute('align') === 'right') {
+      computeAlign = '0px 0px 0px auto'
+    }
     const p = {
       'border-top': ['style', 'width', 'color']
         .map((attr) => this.getAttribute(`border-${attr}`))
         .join(' '),
       'font-size': '1px',
-      margin:
-        this.getAttribute(`align`) === 'center'
-          ? '0px auto'
-          : this.getAttribute(`align`) === 'left'
-          ? '0px'
-          : '0px 0px 0px auto',
+      margin: computeAlign,
       width: this.getAttribute('width'),
     }
 

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -16,6 +16,7 @@ export default class MjDivider extends BodyComponent {
     'padding-right': 'unit(px,%)',
     'padding-top': 'unit(px,%)',
     width: 'unit(px,%)',
+    align: 'enum(left, center, right)',
   }
 
   static defaultAttributes = {
@@ -24,6 +25,7 @@ export default class MjDivider extends BodyComponent {
     'border-width': '4px',
     padding: '10px 25px',
     width: '100%',
+    align: 'center',
   }
 
   getStyles() {
@@ -32,7 +34,12 @@ export default class MjDivider extends BodyComponent {
         .map((attr) => this.getAttribute(`border-${attr}`))
         .join(' '),
       'font-size': '1px',
-      margin: '0px auto',
+      margin:
+        this.getAttribute(`align`) === 'center'
+          ? '0px auto'
+          : this.getAttribute(`align`) === 'left'
+          ? '0px'
+          : '0px 0px 0px auto',
       width: this.getAttribute('width'),
     }
 


### PR DESCRIPTION
Hi! I'd like to add align attribute for `<mj-divider />`, so I created this pull request.

I can't include litmus/email on acid screenshot because I don't have an account. But if there is a compatibility issue I'd be happy to work on it and provide a working version for this simple feature.

This PR would help resolve this issue #407 without using a workaround. 