### PR TITLE
add `@babel/runtime` dep directly to mjml

### DIFF
--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -26,6 +26,7 @@
     "test": "node ./test/test-html-attributes.js"
   },
   "dependencies": {
+    "@babel/runtime": "^7.8.7",
     "mjml-accordion": "4.7.1",
     "mjml-body": "4.7.1",
     "mjml-button": "4.7.1",


### PR DESCRIPTION
Hopefully fixes #1905 and makes it compatible with yarn v2