### PR TITLE
Update index.js

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -246,36 +246,38 @@ export default class MjColumn extends BodyComponent {
           width: '100%',
         })}
       >
-        ${this.renderChildren(children, {
-          renderer: (component) =>
-            component.constructor.isRawElement()
-              ? component.render()
-              : `
-            <tr>
-              <td
-                ${component.htmlAttributes({
-                  align: component.getAttribute('align'),
-                  'vertical-align': component.getAttribute('vertical-align'),
-                  class: component.getAttribute('css-class'),
-                  style: {
-                    background: component.getAttribute(
-                      'container-background-color',
-                    ),
-                    'font-size': '0px',
-                    padding: component.getAttribute('padding'),
-                    'padding-top': component.getAttribute('padding-top'),
-                    'padding-right': component.getAttribute('padding-right'),
-                    'padding-bottom': component.getAttribute('padding-bottom'),
-                    'padding-left': component.getAttribute('padding-left'),
-                    'word-break': 'break-word',
-                  },
-                })}
-              >
-                ${component.render()}
-              </td>
-            </tr>
-          `,
-        })}
+        <tbody>
+          ${this.renderChildren(children, {
+            renderer: (component) =>
+              component.constructor.isRawElement()
+                ? component.render()
+                : `
+              <tr>
+                <td
+                  ${component.htmlAttributes({
+                    align: component.getAttribute('align'),
+                    'vertical-align': component.getAttribute('vertical-align'),
+                    class: component.getAttribute('css-class'),
+                    style: {
+                      background: component.getAttribute(
+                        'container-background-color',
+                      ),
+                      'font-size': '0px',
+                      padding: component.getAttribute('padding'),
+                      'padding-top': component.getAttribute('padding-top'),
+                      'padding-right': component.getAttribute('padding-right'),
+                      'padding-bottom': component.getAttribute('padding-bottom'),
+                      'padding-left': component.getAttribute('padding-left'),
+                      'word-break': 'break-word',
+                    },
+                  })}
+                >
+                  ${component.render()}
+                </td>
+              </tr>
+            `,
+          })}
+        </tbody>
       </table>
     `
   }


### PR DESCRIPTION
Added missing <tbody> after <table> tag in mj-column component.

----
It's better to fix issue with missing <tbody> after <table> tag now.

As with new feature `<mj-html-attributes>` users might try to target tags inside mj-column with child combinator `>` and as there is no <tbody> inside they might see an issue where in Google Chrome inspector they will see <tbody> tag in HTML, but in actual html file this tag would be missing.

@iRyusa you might remember conversation regarding this situation in slack.