### PR TITLE
Mj-section_cut_extra_aside

### DIFF
--- a/packages/mjml-section/README.md
+++ b/packages/mjml-section/README.md
@@ -28,11 +28,7 @@ changed to 100%.
 </aside>
 
 <aside class="warning">
-  Sections cannot be nested into sections. Also, any content in a section should also be wrapped in a column.
-</aside>
-
-<aside class="warning">
-  Sections cannot be nested into sections. Also, any content in a section should also be wrapped in a column.
+  Sections cannot nest in sections. Columns can nest in sections; all content must be in a column.
 </aside>
 
 attribute             | unit        | description                    | default value


### PR DESCRIPTION
A "warning" aside is duplicated early in packages/mjml-section/README.md. This deletes one of them.

Further, this shortens the wording in that aside. It removes awkward wording and clarifies.

It gets the same message across better.

No change to any JavaScript file.