### PR TITLE
Fixed background image bug in Yahoo and AOL (mjml-hero) closes #2098

### DIFF
--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -99,8 +99,6 @@ export default class MjHero extends BodyComponent {
       },
       hero: {
         background: this.getBackground(),
-        'background-position': this.getAttribute('background-position'),
-        'background-repeat': 'no-repeat',
         'border-radius': this.getAttribute('border-radius'),
         padding: this.getAttribute('padding'),
         'padding-top': this.getAttribute('padding-top'),
@@ -155,7 +153,7 @@ export default class MjHero extends BodyComponent {
       this.getAttribute('background-color'),
       ...(this.getAttribute('background-url')
         ? [
-            `url(${this.getAttribute('background-url')})`,
+            `url('${this.getAttribute('background-url')}')`,
             'no-repeat',
             `${this.getAttribute('background-position')} / cover`,
           ]


### PR DESCRIPTION
AOL and Yahoo doesn't show background image if url() function doesn't receive an image in quotes.

Test result:
https://litmus.com/pub/c96d831

Also I noticed that `getBackground()` returns shorthand `background` style, and then `getStyles()` in `hero` object  returned again `background-position` and `background-repeat` which I removed not sure if that was for some hack or no, but test shows that all is ok.