### PR TITLE
Fixed mjml-spacer in outlook closes #1971

### DIFF
--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -1,7 +1,5 @@
 import { BodyComponent } from 'mjml-core'
 
-import conditionalTag from 'mjml-core/lib/helpers/conditionalTag'
-
 export default class MjSpacer extends BodyComponent {
   static allowedAttributes = {
     border: 'string',

--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -26,6 +26,7 @@ export default class MjSpacer extends BodyComponent {
     return {
       div: {
         height: this.getAttribute('height'),
+        'line-height': this.getAttribute('height'),
       },
     }
   }
@@ -34,22 +35,11 @@ export default class MjSpacer extends BodyComponent {
     const height = this.getAttribute('height')
 
     return `
-      ${conditionalTag(`
-        <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td height="${parseInt(
-          height,
-          10,
-        )}" style="height:${height};">
-      `)}
       <div
         ${this.htmlAttributes({
           style: 'div',
         })}
-      >
-        &nbsp;
-      </div>
-      ${conditionalTag(`
-        </td></tr></table>
-      `)}
+      >&#8202;</div>
     `
   }
 }

--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -30,8 +30,6 @@ export default class MjSpacer extends BodyComponent {
   }
 
   render() {
-    const height = this.getAttribute('height')
-
     return `
       <div
         ${this.htmlAttributes({


### PR DESCRIPTION
For some reason outlook didn't respect spacer height, may be it's because of line-height (there were spaces between &nbsp;)

example markup I used
```
<mj-section background-color="#000000"
    padding="20px 0">
      <mj-column>
        <mj-spacer
        container-background-color="#00c72b" />
      </mj-column>
    </mj-section>
    <mj-section background-color="#000000"
    padding="20px 0">
      <mj-column>
        <mj-spacer
        height="5px"
        container-background-color="#00c72b" />
      </mj-column>
    </mj-section>
    <mj-section background-color="#000000"
    padding="20px 0">
      <mj-column>
        <mj-spacer
        height="1px"
        container-background-color="#00c72b" />
      </mj-column>
    </mj-section>
```
Before fix:
![image](https://user-images.githubusercontent.com/13041082/103140669-22836b00-46f2-11eb-95ad-308ea10bfba5.png)
 

After fix:
![image](https://user-images.githubusercontent.com/13041082/103140674-2c0cd300-46f2-11eb-8b40-d7844cc0c301.png)

Used this markup example in mjml-spacer https://www.goodemailcode.com/email-code/spacing.