### PR TITLE
Fix error with code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ var htmlOutput = mjml2html(`
   Print the responsive HTML generated and MJML errors if any
 */
 console.log(htmlOutput)
+```
 
 ## API
 


### PR DESCRIPTION
Correctly end the JavaScript code block in the main README.md.