### PR TITLE
Fixes TypeError when attributes is omitted in JSON-format input

### DIFF
--- a/packages/mjml-validator/src/rules/validAttributes.js
+++ b/packages/mjml-validator/src/rules/validAttributes.js
@@ -15,7 +15,7 @@ export default function validateAttribute(element, { components }) {
     ...Object.keys(Component.allowedAttributes || {}),
     ...WHITELIST,
   ]
-  const unknownAttributes = Object.keys(attributes).filter(
+  const unknownAttributes = Object.keys(attributes || {}).filter(
     (attribute) => !availableAttributes.includes(attribute),
   )
 

--- a/packages/mjml-validator/src/rules/validTypes.js
+++ b/packages/mjml-validator/src/rules/validTypes.js
@@ -11,7 +11,7 @@ export default function validateType(element, { components, initializeType }) {
 
   const errors = []
 
-  for (const [attr, value] of Object.entries(attributes)) {
+  for (const [attr, value] of Object.entries(attributes || {})) {
     const attrType =
       Component.allowedAttributes && Component.allowedAttributes[attr]
     if (attrType) {


### PR DESCRIPTION
In the re-written 4.8.0 validator, the `attributes: {}` property causes a TypeError if omitted from JSON input. This PR fixes that error and returns the behaviour to that of previous versions.