### PR TITLE
Made calculation changes within index.js

### DIFF
--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -67,9 +67,9 @@ export default class MjDivider extends BodyComponent {
 
     switch (unit) {
       case '%':
-        const effectiveWidth = parseInt(containerWidth, 10) - paddingSize;
-        const percentMultiplier = parseInt(parsedWidth, 10) / 100;
-        return `${effectiveWidth * percentMultiplier}px`;
+        const effectiveWidth = parseInt(containerWidth, 10) - paddingSize
+        const percentMultiplier = parseInt(parsedWidth, 10) / 100
+        return `${effectiveWidth * percentMultiplier}px`
       case 'px':
         return width
       default:

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -67,10 +67,9 @@ export default class MjDivider extends BodyComponent {
 
     switch (unit) {
       case '%':
-        return `${
-          (parseInt(containerWidth, 10) * parseInt(parsedWidth, 10)) / 100 -
-          paddingSize
-        }px`
+        const effectiveWidth = parseInt(containerWidth, 10) - paddingSize;
+        const percentMultiplier = parseInt(parsedWidth, 10) / 100;
+        return `${effectiveWidth * percentMultiplier}px`;
       case 'px':
         return width
       default:

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -66,10 +66,11 @@ export default class MjDivider extends BodyComponent {
     const { parsedWidth, unit } = widthParser(width)
 
     switch (unit) {
-      case '%':
+      case '%': {
         const effectiveWidth = parseInt(containerWidth, 10) - paddingSize
         const percentMultiplier = parseInt(parsedWidth, 10) / 100
         return `${effectiveWidth * percentMultiplier}px`
+      }
       case 'px':
         return width
       default:


### PR DESCRIPTION
Noticed divider width was being parsed incorrectly within outlook conditional tables (ie: `width:6%` was being parsed as `width:-64px` for outlook).

Corrected calculation for `getOutlookWidth` within index.js so email padding is subtracted from the email width rather than the parsed width.