### PR TITLE
Docs: Fix relative Try-it-live links in the documentation

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -10,7 +10,7 @@ Here is the final render we want to end with:
 </p>
 
 <p align="center">
-  <a href="/try-it-live/templates/basic"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
+  <a href="https://mjml.io/try-it-live/templates/basic"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
 </p>
 
 Looks cool, right?

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -43,5 +43,5 @@ MJML has been designed with responsiveness in mind. The abstraction it offers gu
   <br />
   <br />
   <br />
-  <a href="/try-it-live/intro"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
+  <a href="https://mjml.io/try-it-live/intro"><img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="try it live" /></a>
 </p>


### PR DESCRIPTION
From the documentation page https://documentation.mjml.io/ two "Try-it-live"-Links are broken.