### PR TITLE
Reduce global components usage

### DIFF
--- a/packages/mjml-core/src/components.js
+++ b/packages/mjml-core/src/components.js
@@ -6,23 +6,4 @@ export function registerComponent(Component) {
   components[Component.componentName || kebabCase(Component.name)] = Component
 }
 
-export function initComponent({ initialDatas, name }) {
-  const Component = components[name]
-
-  if (Component) {
-    const component = new Component(initialDatas)
-
-    if (component.headStyle) {
-      component.context.addHeadStyle(name, component.headStyle)
-    }
-    if (component.componentHeadStyle) {
-      component.context.addComponentHeadSyle(component.componentHeadStyle)
-    }
-
-    return component
-  }
-
-  return null
-}
-
 export default components

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -261,7 +261,7 @@ export class HeadComponent extends Component {
   }
 
   handlerChildren() {
-    const children = this.props.children
+    const { children } = this.props
 
     return children.map((children) => {
       const component = initComponent({

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -16,7 +16,24 @@ import shorthandParser, { borderParser } from './helpers/shorthandParser'
 import formatAttributes from './helpers/formatAttributes'
 import jsonToXML from './helpers/jsonToXML'
 
-import components, { initComponent } from './components'
+export function initComponent({ initialDatas, name }) {
+  const Component = initialDatas.context.components[name]
+
+  if (Component) {
+    const component = new Component(initialDatas)
+
+    if (component.headStyle) {
+      component.context.addHeadStyle(name, component.headStyle)
+    }
+    if (component.componentHeadStyle) {
+      component.context.addComponentHeadSyle(component.componentHeadStyle)
+    }
+
+    return component
+  }
+
+  return null
+}
 
 class Component {
   static getTagName() {
@@ -75,7 +92,7 @@ class Component {
       // supports returning siblings elements from a custom component
       const partialMjml = MJMLParser(`<fragment>${mjml}</fragment>`, {
         ...options,
-        components,
+        components: this.context.components,
         ignoreIncludes: true,
       })
       return partialMjml.children
@@ -180,7 +197,7 @@ export class BodyComponent extends Component {
     )
   }
 
-  renderChildren(childrens, options = {}) {
+  renderChildren(children, options = {}) {
     const {
       props = {},
       renderer = (component) => component.render(),
@@ -188,23 +205,25 @@ export class BodyComponent extends Component {
       rawXML = false,
     } = options
 
-    childrens = childrens || this.props.children
+    children = children || this.props.children
 
     if (rawXML) {
-      return childrens.map((child) => jsonToXML(child)).join('\n')
+      return children.map((child) => jsonToXML(child)).join('\n')
     }
 
-    const sibling = childrens.length
+    const sibling = children.length
 
-    const rawComponents = filter(components, (c) => c.isRawElement())
-    const nonRawSiblings = childrens.filter(
+    const rawComponents = filter(this.context.components, (c) =>
+      c.isRawElement(),
+    )
+    const nonRawSiblings = children.filter(
       (child) => !find(rawComponents, (c) => c.getTagName() === child.tagName),
     ).length
 
     let output = ''
     let index = 0
 
-    forEach(childrens, (children) => {
+    forEach(children, (children) => {
       const component = initComponent({
         name: children.tagName,
         initialDatas: {
@@ -242,9 +261,9 @@ export class HeadComponent extends Component {
   }
 
   handlerChildren() {
-    const childrens = this.props.children
+    const children = this.props.children
 
-    return childrens.map((children) => {
+    return children.map((children) => {
       const component = initComponent({
         name: children.tagName,
         initialDatas: {

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -18,8 +18,8 @@ import cheerio from 'cheerio'
 import MJMLParser from 'mjml-parser-xml'
 import MJMLValidator, { dependencies } from 'mjml-validator'
 import { handleMjml3 } from 'mjml-migrate'
-
-import components, { initComponent, registerComponent } from './components'
+import { initComponent } from './createComponent'
+import components, { registerComponent } from './components'
 
 import suffixCssClasses from './helpers/suffixCssClasses'
 import mergeOutlookConditionnals from './helpers/mergeOutlookConditionnals'
@@ -251,6 +251,7 @@ export default function mjml2html(mjml, options = {}) {
   }
 
   const bodyHelpers = {
+    components,
     addMediaQuery(className, { parsedWidth, unit }) {
       globalDatas.mediaQueries[
         className
@@ -269,6 +270,7 @@ export default function mjml2html(mjml, options = {}) {
   }
 
   const headHelpers = {
+    components,
     add(attr, ...params) {
       if (Array.isArray(globalDatas[attr])) {
         globalDatas[attr].push(...params)


### PR DESCRIPTION
In https://github.com/mjmlio/mjml/pull/2060 I want to pass `presets` without mutating global components.
In this diff I changed components map to be consumed from context in
component implementations.