### PR TITLE
Add support for title attribute in mj-button

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -60,6 +60,7 @@ padding-right               | px          | right offset                        
 padding-top                 | px          | top offset                                       | n/a
 rel                         | string      | specify the rel attribute for the button link    | n/a
 target                      | string      | specify the target attribute for the button link | \_blank
+title                       | string      | tooltip & accessibility                          | n/a
 text-align                  | string      | text-align button content                        | none
 text-decoration             | string      | underline/overline/none                          | none
 text-transform              | string      | capitalize/uppercase/lowercase                   | none

--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -60,9 +60,9 @@ padding-right               | px          | right offset                        
 padding-top                 | px          | top offset                                       | n/a
 rel                         | string      | specify the rel attribute for the button link    | n/a
 target                      | string      | specify the target attribute for the button link | \_blank
-title                       | string      | tooltip & accessibility                          | n/a
 text-align                  | string      | text-align button content                        | none
 text-decoration             | string      | underline/overline/none                          | none
 text-transform              | string      | capitalize/uppercase/lowercase                   | none
+title                       | string      | tooltip & accessibility                          | n/a
 vertical-align              | string      | vertical alignment                               | middle
 width                       | px          | button width                                     | n/a

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -25,6 +25,7 @@ export default class MjButton extends BodyComponent {
     height: 'unit(px,%)',
     href: 'string',
     name: 'string',
+    title: 'string',
     'inner-padding': 'unit(px,%){1,4}',
     'letter-spacing': 'unitWithNegative(px,em)',
     'line-height': 'unit(px,%,)',
@@ -150,6 +151,7 @@ export default class MjButton extends BodyComponent {
                 href: this.getAttribute('href'),
                 rel: this.getAttribute('rel'),
                 name: this.getAttribute('name'),
+                title: this.getAttribute('title'),
                 style: 'content',
                 target: tag === 'a' ? this.getAttribute('target') : undefined,
               })}


### PR DESCRIPTION
This is added to the last element, a or p as the title attribute similarly to name. Closes #2175