### PR TITLE
Accordion-docs-3

### DIFF
--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -48,16 +48,11 @@
   <a href="https://mjml.io/try-it-live/components/accordion">
     <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy" />
   </a>
-</p>
-
-<aside class="notice">
-Every attribute in `mj-accordion` are applied to `mj-accordion-element` unless you override them on `mj-accordion-element`
-</aside>
 
 
 attribute | unit | description | default value
 ----------|------|-------------|---------------
-border | n/a | border | n/a
+border | string | CSS border format | none
 container-background-color | n/a | background-color of the cell | n/a,
 css-class | string | class name, added to the root HTML element created | n/a
 font-family | n/a | font | Ubuntu, Helvetica, Arial, sans-serif
@@ -77,11 +72,18 @@ padding-top | px | padding top | n/a
 
 ### mj-accordion-element
 
-This component enables you to create a accordion pane
+Creates an accordion title/text pair.
+An accordion can have any number of these pairs.
+
+<aside class="notice">
+Inheritance applies between attributes supported in both `mj-accordion` and 
+`mj-accordion-element` unless `mj-accordion-element` overrides.
+</aside>
 
 attribute | unit | description | default value
 ----------|------|-------------|---------------
 background-color | n/a | background color | n/a
+border | n/a | border | affects each horizontal border in the accordion except the top one
 css-class | string | class name, added to the root HTML element created | n/a
 font-family | n/a | font | Ubuntu, Helvetica, Arial, sans-serif
 icon-align | n/a | icon alignment | middle
@@ -95,7 +97,7 @@ icon-wrapped-url | n/a | icon when accordion is wrapped | https://i.imgur.com/bI
 
 ### mj-accordion-title
 
-This component enables you to add and style a title to your accordion
+The title in a title/text pair.
 
 attribute | unit | description | default value
 ----------|------|-------------|---------------
@@ -112,7 +114,7 @@ padding-top | px | padding top | n/a
 
 ### mj-accordion-text
 
-This component enables you to add and style a text to your accordion
+The text in a title/text pair.
 
 attribute | unit | description | default value
 ----------|------|-------------|---------------
@@ -129,4 +131,3 @@ padding-bottom | px | padding bottom | n/a
 padding-left | px | padding left | n/a
 padding-right | px | padding right | n/a
 padding-top | px | padding top | n/a
-

--- a/packages/mjml-accordion/src/AccordionElement.js
+++ b/packages/mjml-accordion/src/AccordionElement.js
@@ -9,6 +9,7 @@ export default class MjAccordionElement extends BodyComponent {
 
   static allowedAttributes = {
     'background-color': 'color',
+    border: 'string',
     'font-family': 'string',
     'icon-align': 'enum(top,middle,bottom)',
     'icon-width': 'unit(px,%)',


### PR DESCRIPTION
Changes for mjml-accordion, both documentation and JavaScript.

### This PR

Adds attribute `border` to the list of attributes `accordion-element` supports, both in documentation (README.md) and in JavaScript (AccordionElement.js; `allowedAttributes`). Related discussion #2157 and #2159.

Also, though previous authors have done a nice job creating this documentation, there are tweaks here to make the documentation still more useful. I explain my reasons for each because it seems my suggestions are better accepted when I express those reasons.

Improves some grammar.
Improves some awkward wording and shortens some sentences.

[accordion-docs-3.diff.txt](https://github.com/mjmlio/mjml/files/5983306/accordion-docs-3.diff.txt)
(remove .txt extension for .diff file)

### border and mj-accordion-element Issue #2157
MJML documentation for mj-accordion-element does not indicate support for attribute border. However, using border there changes the rendering of all horizontal borders in the accordion except the top border. (An unusual effect.)

The structure of the code is assessed as indicating this status is intentional, so we're changing the documentation. In the documentation, see the attribute list for mj-accordion-element > border.

### Grammar
An `aside` in mj-accordion uses sentence structure, "Every attribute in mj-accordion are applied". The verb could be better.

The text in mj-accordion-element mentions "a accordion pane". The article could be better.

### Expression
The aside in mj-accordion (already mentioned) is about attributes in mj-accordion and mj-accordion-element, as well as about effects in mj-accordion-element. A more natural placement is with mj-accordion-element. The proposed location is with mj-accordion-element.

A sentence structure used in mj-accordion-element, mj-accordion-title, and mj-accordion-text includes, "This component enables you". Both pairs of words lengthen the sentences without adding content. See the shorter phrases in each section.

The text in mj-accordion-title is a compound sentence. It's awkward because when broken into two sentences, one is, "This component enables you to style a title to your accordion." For this half of the sentence, "in" is better than "to", but not for the other half. The sentence could be better. See new text there.

The text in mj-accordion-element introduces a term--"accordion pane"--that is not defined and never used again. That can be better. I propose using "title/text pair" instead. See related changes in mj-accordion-element, mj-accordion-title, and mj-accordion-text.

### Slight addition

In current documentation, it's unsaid why mj-accordion-element exists. It's reasonably clear why the others exist. If we can find a short sentence to introduce the concept, the documentation improves. I propose one.