### PR TITLE
accordion-docs-3.1

### DIFF
--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -48,7 +48,7 @@
   <a href="https://mjml.io/try-it-live/components/accordion">
     <img width="100px" src="https://mjml.io/assets/img/svg/TRYITLIVE.svg" alt="sexy" />
   </a>
-
+</p>
 
 attribute | unit | description | default value
 ----------|------|-------------|---------------


### PR DESCRIPTION
change only to packages/mjml-accordion/README.md

Problem: incorrectly rendered attribute tables in the documentation

Action: Add back the `</p>` that precedes the first attribute table.

Result: The documentation renders properly in VS Studio Code.