### PR TITLE
fix background-color on outlook when no-repeat

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -189,6 +189,9 @@ export default class MjSection extends BodyComponent {
 
   renderBefore() {
     const { containerWidth } = this.context
+    const bgcolorAttr = this.getAttribute('background-color')
+      ? { bgcolor: this.getAttribute('background-color') }
+      : {}
 
     return `
       <!--[if mso | IE]>
@@ -201,6 +204,7 @@ export default class MjSection extends BodyComponent {
           class: suffixCssClasses(this.getAttribute('css-class'), 'outlook'),
           style: { width: `${containerWidth}` },
           width: parseInt(containerWidth, 10),
+          ...bgcolorAttr,
         })}
       >
         <tr>


### PR DESCRIPTION
Since 4.7 we support background-image `no-repeat` properly in outlook's vml
However i just noticed while investigating the background-position issue that when a background-color is set too, then the color only fills the transparent parts of the background-image (bgcolor is blue here) :
![image](https://user-images.githubusercontent.com/8144509/110366408-8a392900-8046-11eb-877d-fb546d504af9.png)

Adding the `bgcolor` attribute on the wrapping `td` inside the conditional allows the color to fill the entire section, and doesn't seem to overlap the content in any way.