### PR TITLE
Hide Outlook XML DPI on T-Online

### DIFF
--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -42,12 +42,14 @@ export default function skeleton(options) {
           p { display:block;margin:13px 0; }
         </style>
         <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
         <!--[if lte mso 11]>
         <style type="text/css">


### PR DESCRIPTION
T-Online is showing the number '96' on top of the email when the Outlook XML DPI fix is present in the code.
I came across this bug and Mark Robbins suggested a `<noscript>` tag that is working wonderfully.
More details here:
https://github.com/hteumeuleu/email-bugs/issues/83