### PR TITLE
fix invalid HTML comments in skeleton

### DIFF
--- a/packages/mjml-core/src/helpers/skeleton.js
+++ b/packages/mjml-core/src/helpers/skeleton.js
@@ -29,9 +29,9 @@ export default function skeleton(options) {
         <title>
           ${title}
         </title>
-        <!--[if !mso]><!-->
+        <!--[if !mso]>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <!--<![endif]-->
+        <![endif]-->
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <style type="text/css">


### PR DESCRIPTION
This skeleton contains some HTML comments inside the conditional comment which I believe is illegal in HTML. This was added in 7fdd028d0e8b03e0bd73fddeec67d53f799be6fe but the additional comments seem to be an accidental change.