### PR TITLE
mj-button_link

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -1,14 +1,16 @@
 ## mj-button
 
 <p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/6558790/12751346/fd993192-c9bc-11e5-8c91-37d616bf5874.png" alt="desktop" width="150px" />
+  <img src="https://cloud.githubusercontent.com/assets/6558790/12751346/fd993192-c9bc-11e5-8c91-37d616bf5874.png"
+       alt="desktop" width="150px" />
 </p>
 
 Displays a customizable button.
 
 <aside class="notice">
   The `mj-button` won't be fully clickable because of client support.
-  See discussion at [Issue #359](https://github.com/mjmlio/mjml/issues/359).
+  See discussion at
+    <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a>.
 </aside>
 
 ```xml


### PR DESCRIPTION
**Effect of Changes**

Only to `packages/mjml-button/README.md`

**Problem**

Raw Markdown notation appears in the documentation.

![button](https://user-images.githubusercontent.com/14095071/113962440-4ecc7e80-97ed-11eb-83c5-b2fd9bcf78a2.PNG)

**Action**

Change to equivalent HTTP notation.

```
<aside class="notice">
  The `mj-button` won't be fully clickable because of client support.
  See discussion at
    <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a>.
</aside>
```

**Result**

The documentation renders properly in the Markdown engine I use.

![correct](https://user-images.githubusercontent.com/14095071/113962712-d7e3b580-97ed-11eb-9d25-d53ae2952444.PNG)