### PR TITLE
mj-font_external_fonts

### DIFF
--- a/packages/mjml-head-font/README.md
+++ b/packages/mjml-head-font/README.md
@@ -30,6 +30,17 @@ Example: [https://fonts
   </a>
 </p>
 
+<aside class="notice">
+  "mj-font" cannot work if the email client doesn't support external fonts.
+  <a href="https://www.caniemail.com/features/css-at-font-face/"
+     target="_blank"
+     referrerpolicy="no-referrer"
+     rel="noreferrer noopener"
+     title="link to caniemail.com/features/css-at-font-face"
+   >https://www.caniemail.com/features/css-at-font-face/</a >
+   may help.
+</aside>
+
 attribute   | unit     | description                | default value
 ------------|----------|----------------------------|---------------
 href        | string   | URL of a hosted CSS file   | n/a


### PR DESCRIPTION
**Changes**

Only to packages/mjml-font/README.md

**Problem**

@tonyketcham, in Issue #2215 suggested additional information about client support of external fonts in "mj-font"

**Action**

Add an aside pointing to https://www.caniemail.com/features/css-at-font-face/

**Result**

Resolves Issue #2215