### PR TITLE
[FIX] Non-escaped attributes in Carousel Image

### DIFF
--- a/packages/mjml-carousel/src/CarouselImage.js
+++ b/packages/mjml-carousel/src/CarouselImage.js
@@ -140,7 +140,7 @@ export default class MjCarouselImage extends BodyComponent {
       >
         ${
           href
-            ? `<a href=${href} rel=${rel} target="_blank">${image}</a>`
+            ? `<a ${this.htmlAttributes({ href, rel, target: "_blank" })}>${image}</a>`
             : image
         }
       </div>


### PR DESCRIPTION
cc @kmcb777 