### PR TITLE
Fix background image in mj-section for Yahoo and AOL.

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -112,7 +112,7 @@ export default class MjSection extends BodyComponent {
       this.getAttribute('background-color'),
       ...(this.hasBackground()
         ? [
-            `url(${this.getAttribute('background-url')})`,
+            `url('${this.getAttribute('background-url')}')`,
             this.getBackgroundString(),
             `/ ${this.getAttribute('background-size')}`,
             this.getAttribute('background-repeat'),


### PR DESCRIPTION
Related to #2098 and #2122

As I understand it will also fix mj-wrapper with background images in Yahoo and AOL