### PR TITLE
If preview text exists don't display body text as preview

### DIFF
--- a/packages/mjml-core/src/helpers/preview.js
+++ b/packages/mjml-core/src/helpers/preview.js
@@ -7,5 +7,8 @@ export default function (content) {
     <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">
       ${content}
     </div>
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+    </div>
   `
 }


### PR DESCRIPTION
closes #1829

We ran into an issue were preview text from the body of the email was being displayed after the preview text.
We found this article about how to prevent it and it's been working well for a couple months now.

This is based off this litmus article: https://www.litmus.com/blog/the-little-known-preview-text-hack-you-may-want-to-use-in-every-email/

Also thanks to @j56xie for her work finding this.

Example of the errors this fixes:
![110679311-532d5980-81a5-11eb-9d2c-2b4911c240e0](https://user-images.githubusercontent.com/6425087/119238633-97c46200-bb11-11eb-98d4-3a0c5aa26567.png)