### PR TITLE
feat: add support for ESM module transpilation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,10 @@
+const ESM = process.env.ESM === 'true'
+
 module.exports = {
   presets: [['@babel/env', {
     targets: { node: '10' },
     include: ['transform-classes'],
+    ...(ESM ? { modules: false } : {}),
   }]],
   plugins: [
     '@babel/proposal-class-properties',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "scripts": {
     "build:watch": "lerna run build --parallel -- -- -w",
-    "build": "lerna run build --parallel --ignore mjml-browser",
+    "build": "yarn run build:cjs && yarn run build:esm",
+    "build:cjs": "lerna run build --parallel --ignore mjml-browser",
+    "build:esm": "cross-env ESM=true lerna run build:esm --parallel --ignore mjml-browser --ignore mjml-cli --ignore mjml-migrate",
     "build-browser": "cd packages/mjml-browser && yarn build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -22,6 +24,7 @@
     "babel-eslint": "^10.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-lodash": "^3.3.4",
+    "cross-env": "^7.0.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",

--- a/packages/mjml-accordion/package.json
+++ b/packages/mjml-accordion/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-accordion",
   "description": "mjml-accordion",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-accordion/src/AccordionElement.js
+++ b/packages/mjml-accordion/src/AccordionElement.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 import { find } from 'lodash'
-import conditionalTag from 'mjml-core/lib/helpers/conditionalTag'
+import conditionalTag from 'mjml-core/lib/esm/helpers/conditionalTag'
 import AccordionText from './AccordionText'
 import AccordionTitle from './AccordionTitle'
 

--- a/packages/mjml-accordion/src/AccordionTitle.js
+++ b/packages/mjml-accordion/src/AccordionTitle.js
@@ -1,5 +1,5 @@
 import { BodyComponent } from 'mjml-core'
-import conditionalTag from 'mjml-core/lib/helpers/conditionalTag'
+import conditionalTag from 'mjml-core/lib/esm/helpers/conditionalTag'
 
 export default class MjAccordionTitle extends BodyComponent {
   static componentName = 'mj-accordion-title'

--- a/packages/mjml-body/package.json
+++ b/packages/mjml-body/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-body",
   "description": "mjml-body",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-button/package.json
+++ b/packages/mjml-button/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-button",
   "description": "mjml-button",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 export default class MjButton extends BodyComponent {
   static componentName = 'mj-button'

--- a/packages/mjml-carousel/package.json
+++ b/packages/mjml-carousel/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-carousel",
   "description": "mjml-carousel",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-carousel/src/Carousel.js
+++ b/packages/mjml-carousel/src/Carousel.js
@@ -2,7 +2,7 @@ import { BodyComponent } from 'mjml-core'
 import { range, repeat, min, map } from 'lodash'
 import crypto from 'crypto'
 
-import { msoConditionalTag } from 'mjml-core/lib/helpers/conditionalTag'
+import { msoConditionalTag } from 'mjml-core/lib/esm/helpers/conditionalTag'
 
 export default class MjCarousel extends BodyComponent {
   static componentName = 'mj-carousel'

--- a/packages/mjml-column/package.json
+++ b/packages/mjml-column/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-column",
   "description": "mjml-column",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 export default class MjColumn extends BodyComponent {
   static componentName = 'mj-column'

--- a/packages/mjml-core/package.json
+++ b/packages/mjml-core/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-core",
   "description": "mjml-core",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward",
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward",
     "test": "node ./tests/index.js"
   },
   "dependencies": {

--- a/packages/mjml-core/tests/jsonToXml-test.js
+++ b/packages/mjml-core/tests/jsonToXml-test.js
@@ -1,5 +1,5 @@
 const chai = require('chai')
-const jsonToXml = require('../lib/helpers/jsonToXML')
+const jsonToXml = require('../lib/cjs/helpers/jsonToXML')
 
 const json = {
   line: 1,

--- a/packages/mjml-core/tests/mergeOutlookConditionnals-test.js
+++ b/packages/mjml-core/tests/mergeOutlookConditionnals-test.js
@@ -1,5 +1,5 @@
 const chai = require('chai')
-const mergeOutlookConditionnals = require('../lib/helpers/mergeOutlookConditionnals')
+const mergeOutlookConditionnals = require('../lib/cjs/helpers/mergeOutlookConditionnals')
 
 const testValues = [
   {

--- a/packages/mjml-core/tests/minifyOutlookConditionnals-test.js
+++ b/packages/mjml-core/tests/minifyOutlookConditionnals-test.js
@@ -1,5 +1,5 @@
 const chai = require('chai')
-const minifyOutlookConditionnals = require('../lib/helpers/minifyOutlookConditionnals')
+const minifyOutlookConditionnals = require('../lib/cjs/helpers/minifyOutlookConditionnals')
 
 const testValues = [
   {

--- a/packages/mjml-core/tests/shorthandParser-test.js
+++ b/packages/mjml-core/tests/shorthandParser-test.js
@@ -1,5 +1,5 @@
 const chai = require('chai')
-const helper = require('../lib/helpers/shorthandParser')
+const helper = require('../lib/cjs/helpers/shorthandParser')
 
 const shorthandParser = helper && helper.default
 

--- a/packages/mjml-core/tests/widthParser-test.js
+++ b/packages/mjml-core/tests/widthParser-test.js
@@ -1,5 +1,5 @@
 const chai = require('chai')
-const widthParser = require('../lib/helpers/widthParser')
+const widthParser = require('../lib/cjs/helpers/widthParser')
 
 const testValues = [
   {

--- a/packages/mjml-divider/package.json
+++ b/packages/mjml-divider/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-divider",
   "description": "mjml-divider",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 export default class MjDivider extends BodyComponent {
   static componentName = 'mj-divider'

--- a/packages/mjml-group/package.json
+++ b/packages/mjml-group/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-group",
   "description": "mjml-group",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-group/src/index.js
+++ b/packages/mjml-group/src/index.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 export default class MjGroup extends BodyComponent {
   static componentName = 'mj-group'

--- a/packages/mjml-head-attributes/package.json
+++ b/packages/mjml-head-attributes/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-attributes",
   "description": "mjml-head-attributes",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-breakpoint/package.json
+++ b/packages/mjml-head-breakpoint/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-breakpoint",
   "description": "mjml-head-breakpoint",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-font/package.json
+++ b/packages/mjml-head-font/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-font",
   "description": "mjml-head-font",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-html-attributes/package.json
+++ b/packages/mjml-head-html-attributes/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-html-attributes",
   "description": "mjml-head-html-attributes",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-preview/package.json
+++ b/packages/mjml-head-preview/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-preview",
   "description": "mjml-head-preview",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-style/package.json
+++ b/packages/mjml-head-style/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-style",
   "description": "mjml-head-style",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head-title/package.json
+++ b/packages/mjml-head-title/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head-title",
   "description": "mjml-head-title",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-head/package.json
+++ b/packages/mjml-head/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-head",
   "description": "mjml-head",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-hero/package.json
+++ b/packages/mjml-hero/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-hero",
   "description": "mjml-hero",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -1,7 +1,7 @@
 import { BodyComponent } from 'mjml-core'
 import { flow, identity, join, filter } from 'lodash/fp'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 const makeBackgroundString = flow(filter(identity), join(' '))
 

--- a/packages/mjml-image/package.json
+++ b/packages/mjml-image/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-image",
   "description": "mjml-image",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -2,7 +2,7 @@ import { min } from 'lodash'
 
 import { BodyComponent } from 'mjml-core'
 
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 export default class MjImage extends BodyComponent {
   static componentName = 'mj-image'

--- a/packages/mjml-navbar/package.json
+++ b/packages/mjml-navbar/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-navbar",
   "description": "mjml-navbar",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-navbar/src/Navbar.js
+++ b/packages/mjml-navbar/src/Navbar.js
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 
 import conditionalTag, {
   msoConditionalTag,
-} from 'mjml-core/lib/helpers/conditionalTag'
+} from 'mjml-core/lib/esm/helpers/conditionalTag'
 
 export default class MjNavbar extends BodyComponent {
   static componentName = 'mj-navbar'

--- a/packages/mjml-navbar/src/NavbarLink.js
+++ b/packages/mjml-navbar/src/NavbarLink.js
@@ -1,6 +1,6 @@
 import { BodyComponent, suffixCssClasses } from 'mjml-core'
 
-import conditionalTag from 'mjml-core/lib/helpers/conditionalTag'
+import conditionalTag from 'mjml-core/lib/esm/helpers/conditionalTag'
 
 export default class MjNavbarLink extends BodyComponent {
   static componentName = 'mj-navbar-link'

--- a/packages/mjml-parser-xml/package.json
+++ b/packages/mjml-parser-xml/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-parser-xml",
   "description": "mjml-parser-xml",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward",
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward",
     "test": "node ./test/test.js"
   },
   "dependencies": {

--- a/packages/mjml-parser-xml/test/test-preprocessors.js
+++ b/packages/mjml-parser-xml/test/test-preprocessors.js
@@ -1,7 +1,7 @@
 const { template } = require('lodash')
-const MJMLParser = require('../lib')
-const mjml2html = require('../../mjml/lib')
-const { components } = require('../../mjml-core/lib')
+const MJMLParser = require('../lib/cjs')
+const mjml2html = require('../../mjml/lib/cjs')
+const { components } = require('../../mjml-core/lib/cjs')
 
 const parse = mjml =>
   MJMLParser(mjml, {

--- a/packages/mjml-preset-core/package.json
+++ b/packages/mjml-preset-core/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-preset-core",
   "description": "mjml-preset-core",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-raw/package.json
+++ b/packages/mjml-raw/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-raw",
   "description": "mjml-raw",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-section/package.json
+++ b/packages/mjml-section/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-section",
   "description": "mjml-section",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-social/package.json
+++ b/packages/mjml-social/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-social",
   "description": "mjml-social",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-spacer/package.json
+++ b/packages/mjml-spacer/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-spacer",
   "description": "mjml-spacer",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-table/package.json
+++ b/packages/mjml-table/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-table",
   "description": "mjml-atable",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-table/src/index.js
+++ b/packages/mjml-table/src/index.js
@@ -1,4 +1,4 @@
-import widthParser from 'mjml-core/lib/helpers/widthParser'
+import widthParser from 'mjml-core/lib/esm/helpers/widthParser'
 
 import { BodyComponent } from 'mjml-core'
 import { reduce } from 'lodash'

--- a/packages/mjml-text/package.json
+++ b/packages/mjml-text/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-text",
   "description": "mjml-text",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -1,6 +1,6 @@
 import { BodyComponent } from 'mjml-core'
 
-import conditionalTag from 'mjml-core/lib/helpers/conditionalTag'
+import conditionalTag from 'mjml-core/lib/esm/helpers/conditionalTag'
 
 export default class MjText extends BodyComponent {
   static componentName = 'mj-text'

--- a/packages/mjml-validator/package.json
+++ b/packages/mjml-validator/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-validator",
   "description": "mjml-validator",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/cjs/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7"

--- a/packages/mjml-wrapper/package.json
+++ b/packages/mjml-wrapper/package.json
@@ -2,7 +2,12 @@
   "name": "mjml-wrapper",
   "description": "mjml-wrapper",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -18,7 +23,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward"
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",

--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -2,7 +2,12 @@
   "name": "mjml",
   "description": "MJML: the only framework that makes responsive-email easy",
   "version": "4.9.3",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "imports": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "bin": {
     "mjml": "bin/mjml"
   },
@@ -22,7 +27,8 @@
   "homepage": "https://mjml.io",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --root-mode upward",
+    "build": "babel src --out-dir lib/cjs --root-mode upward",
+    "build:esm": "babel src --out-dir lib/esm --root-mode upward",
     "test": "node ./test/test-html-attributes.js"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,6 +3301,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3311,6 +3318,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -6611,6 +6627,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -7431,10 +7452,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -8504,6 +8537,13 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
With the rise of dev/build tools like Vite or Esbuild, the ecosystem seems to be going in the direction of ES modules as they're currently supported in all major browsers. Nonetheless, these tools, depending on the library imports being `esm` friendly. And even though, Vite, for example, offers the `optimizeDeps` option in order to get around the issue of some imports not using `esm`, it loses some of the advantages of tree shaking and or it's not possible to use the libraries as plugin for the project config itself; e.g: creating a custom local compilation/preprocess for compiling `<template lang="mjml" />` (`Sveltekit`).

This PR simply adds the required changes in the `package.json` on all the packages that do not involve the browser (`mjml-browser`) and/or the cli (`mjml-cli` & `mjml-migrate`), as I in that case wasn't completely sure what should be the correct direction, but they are libraries that might not be targeted for those dev/build tools from the start. The changes also affect the main `babel.config.js` so that we can target the correct module system based on whether we're building for `cjs` or `esm`.

Hope this can be discussed and improved further if need be.