### PR TITLE
Multiply final mobile width by 100

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -138,7 +138,9 @@ export default class MjColumn extends BodyComponent {
         return width
       case 'px':
       default:
-        return `${parsedWidth / parseInt(containerWidth, 10)}%`
+        const finalWidth = parsedWidth / parseInt(containerWidth, 10) * 100
+        
+        return `${finalWidth}%`
     }
   }
 


### PR DESCRIPTION
After calculating percentage mobile width, the result was not being multiplied by 100, resulting on a total width percentage of 1% (adding all columns)