### PR TITLE
mj-hero_docs

### DIFF
--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -13,6 +13,10 @@ For better results, it's best to use an image with height the same or larger
 Use `background-color` to provide a fallback color
   in case an email client doesn't support `background-url`.
 
+<aside class="notice">
+  The "height" attribute is required only for 'mode="fixed-height"'.
+</aside>
+
 Fixed height
 
 <p align="center">

--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -13,10 +13,6 @@ For better results, it's best to use an image with height the same or larger
 Use `background-color` to provide a fallback color
   in case an email client doesn't support `background-url`.
 
-<aside class="notice">
-  The "height" attribute is required only for 'mode="fixed-height"'.
-</aside>
-
 Fixed height
 
 <p align="center">
@@ -32,7 +28,8 @@ Fixed height
       height="469px"
       background-width="600px"
       background-height="469px"
-      background-url="https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg"
+      background-url=
+          "https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg"
       background-color="#2a3448"
       padding="100px 0px">
       <mj-text
@@ -73,10 +70,10 @@ Fluid height
       mode="fluid-height"
       background-width="600px"
       background-height="469px"
-      background-url="https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg"
+      background-url=
+          "https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg"
       background-color="#2a3448"
-      padding="100px 0px"
-      width="100%">
+      padding="100px 0px">
       <mj-text
         padding="20px"
         color="#ffffff"
@@ -105,10 +102,10 @@ Fluid height
 attribute           | unit                                | description                                                          | default value
 --------------------|-------------------------------------|----------------------------------------------------------------------|--------------
 background-color    | color                               | hero background color                                                | #ffffff
-background-height   | px                                  | height of the image used (mandatory in fixed-height mode)            | none
+background-height   | px                                  | height of the image used, mandatory                                  | none
 background-position | top/center/bottom left/center/right | background image position                                            | center center
 background-url      | url                                 | absolute background url                                              | n/a
-background-width    | px                                  | width of the image used                                              | parent element width
+background-width    | px                                  | width of the image used, mandatory                                   | parent element width
 border-radius       | px                                  | border radius                                                        | n/a
 height              | px                                  | hero section height (required for fixed-height mode)                 | 0px
 mode                | fluid-height/fixed-height           | choose if the height is fixed based on the height attribute or fluid | fluid-height


### PR DESCRIPTION
mj-hero_docs

Today's docs say, for mj-hero:

<aside class="notice">
  The "height" attribute is required only for 'mode="fixed-height"'.
</aside>

In the attributes table are these lines:

attribute         | unit | description                                               | default value
------------------|------|-----------------------------------------------------------|--------------
background-height | px   | height of the image used (mandatory in fixed-height mode) | none
background-width  | px   | width of the image used                                   | parent element width

In Slack recently, iryusa wrote about "background-height" and
    "background-width": They're "mandatory for every mode because
    outlook won’t render background image with a proper ratio".

Our docs can be more accurate.


Changes

Because these two attributes are "mandatory for every mode":

1) Delete the aside.

2) From above table, change the two attributes table rows to:

attribute         | unit | description                         | default value
------------------|------|-------------------------------------|--------------
background-height | px   | height of the image used, mandatory | none
background-width  | px   | width of the image used, mandatory  | parent element width


Because the "width" attribute is absent from the MjHero class "allowedAttributes":

1) Delete the attributes table row

attribute   | unit | description                  | default value
----------- | ---- | ------------------------ | --
width        | px   | hero container width   | parent element width

2) In the second code block of this file (the one closer to the attributes table),
    remove the MJML attribute "width=100%".


I don't recall seeing the warning, "too long for the style guide", before. It's alerting for lines longer than 120 char. Maybe it's an MJML setting, maybe not. Cutting those long lines to within 120 char is a little useful, in any case; I don't support it as a hard-and-fast rule. Two such lines are split into two lines each. It improves readability a (very) little bit, maybe. All lines of the attribute table get that warning; I don't advocate change for those.