### PR TITLE
technical-debt--or--better-classed-components

### DIFF
--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -5,8 +5,6 @@ import widthParser from 'mjml-core/lib/helpers/widthParser'
 export default class MjDivider extends BodyComponent {
   static componentName = 'mj-divider'
 
-  static tagOmission = true
-
   static allowedAttributes = {
     'border-color': 'color',
     'border-style': 'string',

--- a/packages/mjml-head-font/src/index.js
+++ b/packages/mjml-head-font/src/index.js
@@ -3,8 +3,6 @@ import { HeadComponent } from 'mjml-core'
 export default class MjFont extends HeadComponent {
   static componentName = 'mj-font'
 
-  static tagOmission = true
-
   static allowedAttributes = {
     name: 'string',
     href: 'string',

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -7,8 +7,6 @@ import widthParser from 'mjml-core/lib/helpers/widthParser'
 export default class MjImage extends BodyComponent {
   static componentName = 'mj-image'
 
-  static tagOmission = true
-
   static allowedAttributes = {
     alt: 'string',
     href: 'string',


### PR DESCRIPTION
# Status #

`mj-divider`, `mj-font`, and `mj-image` are marked with "static tagOmission = true" in the same place similar components are marked "const endingTags = true".

The string "tagOmission" may not occur anywhere in the MJML code base except those three. 

Are the subject three statements orphaned from the past? Does code that used those locations belong in the code base?