### PR TITLE
Feature request: Add a new attribute in order to get an outlook proof button

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -13,6 +13,10 @@ Displays a customizable button.
     <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a>.
 </aside>
 
+<aside class="warning">
+  The `mj-button` will be duplicated in two html components when mso-proof is true
+</aside>
+
 ```xml
 <mjml>
   <mj-body>
@@ -55,6 +59,9 @@ href                        | link        | link to be triggered when the button
 inner-padding               | px          | inner button padding                             | 10px 25px
 letter-spacing              | px,em       | letter-spacing                                   | n/a
 line-height                 | px/%/none   | line-height on link                              | 120%
+mso-proof                   | boolean     | specify outlook to use roundrect approach        | false
+mso-width                   | px          | roundrect button width                           | 200px
+mso-height                  | px          | roundrect button height                          | 40px
 padding                     | px          | supports up to 4 parameters                      | 10px 25px
 padding-bottom              | px          | bottom offset                                    | n/a
 padding-left                | px          | left offset                                      | n/a

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -41,6 +41,9 @@ export default class MjButton extends BodyComponent {
     'vertical-align': 'enum(top,bottom,middle)',
     'text-align': 'enum(left,right,center)',
     width: 'unit(px,%)',
+    'mso-height': 'unit(px)',
+    'mso-width': 'unit(px)',
+    'mso-proof': 'boolean',
   }
 
   static defaultAttributes = {
@@ -59,6 +62,9 @@ export default class MjButton extends BodyComponent {
     'text-decoration': 'none',
     'text-transform': 'none',
     'vertical-align': 'middle',
+    'mso-height': '40px',
+    'mso-width': '200px',
+    'mso-proof': 'false',
   }
 
   getStyles() {
@@ -100,6 +106,21 @@ export default class MjButton extends BodyComponent {
         'mso-padding-alt': '0px',
         'border-radius': this.getAttribute('border-radius'),
       },
+      msocontainer: {
+        height: this.getAttribute('mso-height'),
+        width: this.getAttribute('mso-width'),
+        padding: this.getAttribute('padding'),
+        'v-text-anchor': 'middle',
+      },
+      msobutton: {
+        color: this.getAttribute('color'),
+        'font-family': this.getAttribute('font-family'),
+        'font-size': this.getAttribute('font-size'),
+        'font-style': this.getAttribute('font-style'),
+        'font-weight': this.getAttribute('font-weight'),
+        'line-height': this.getAttribute('line-height'),
+        'letter-spacing': this.getAttribute('letter-spacing'),
+      },
     }
   }
 
@@ -120,10 +141,83 @@ export default class MjButton extends BodyComponent {
     return `${parsedWidth - innerPaddings - borders}px`
   }
 
+  renderMSO() {
+    const bgColor =
+      this.getAttribute('background-color') === 'none'
+        ? undefined
+        : this.getAttribute('background-color')
+    const radii = !this.getAttribute('border-radius')
+      ? 0
+      : parseInt(this.getAttribute('border-radius'), 10)
+    const height = parseInt(this.getAttribute('mso-height'), 10)
+    let arcsize = 0
+    if (radii > height) arcsize = 100
+    if (radii !== 0 && arcsize !== 100) arcsize = (radii / height) * 100
+
+    let borderAttr = ['0pt', 'Solid', '#000000']
+    const borderstyleAdapter = {
+      solid: 'Solid',
+      dotted: 'Dot',
+      dashed: 'Dash',
+      double: 'Solid',
+      groove: 'Solid',
+      ridge: 'Solid',
+      inset: 'Solid',
+      outset: 'Solid',
+      none: 'Solid',
+      hidden: 'Solid',
+    }
+    const stroked = this.getAttribute('border') !== 'none'
+    if (stroked) {
+      const border = this.getAttribute('border').split(' ')
+      borderAttr = [
+        border.length > 0 ? border[0] : borderAttr[0],
+        border.length > 1 ? borderstyleAdapter[border[1]] : borderAttr[1],
+        border.length === 3 ? border[2] : borderAttr[2],
+      ]
+    }
+    return `
+    <!--[if mso]>
+      <tr>
+        <td ${this.htmlAttributes({
+          align: this.getAttribute('align'),
+        })}>
+          <v:roundrect
+            xmlns:v="urn:schemas-microsoft-com:vml"
+            xmlns:w="urn:schemas-microsoft-com:office:word"
+            ${this.htmlAttributes({
+              href: this.getAttribute('href'),
+              arcsize,
+              fill: bgColor === undefined ? 'f' : 't',
+              strokeweight: stroked ? borderAttr[0] : '0pt',
+              strokecolor: borderAttr[2],
+              stroked: stroked ? 't' : 'f',
+              style: 'msocontainer',
+            })}
+            >
+            ${stroked ? `<v:stroke dashstyle="${borderAttr[1]}" />` : ''}
+            ${
+              bgColor === undefined
+                ? ''
+                : `<v:fill type="tile" color="${bgColor}" />`
+            }
+            <w:anchorlock/>
+            <center ${this.htmlAttributes({ style: 'msobutton' })}>
+              ${this.getContent()}
+            </center>
+          </v:roundrect>
+        </td>
+      </tr>
+    <!<[endif]-->
+    `
+  }
+
   render() {
     const tag = this.getAttribute('href') ? 'a' : 'p'
-
+    const mso = this.getAttribute('mso-proof')
     return `
+      ${mso ? this.renderMSO() : ''}
+      ${mso ? '<!--[if !mso]><!---->' : ''}
       <table
         ${this.htmlAttributes({
           border: '0',
@@ -137,7 +231,7 @@ export default class MjButton extends BodyComponent {
           <tr>
             <td
               ${this.htmlAttributes({
-                align: 'center',
+                align: this.getAttribute('align'),
                 bgcolor:
                   this.getAttribute('background-color') === 'none'
                     ? undefined
@@ -162,6 +256,7 @@ export default class MjButton extends BodyComponent {
           </tr>
         </tbody>
       </table>
+      ${mso ? '<!--<[endif]-->' : ''}
     `
   }
 }


### PR DESCRIPTION
## Purpose

In my current project I had to create a button with a border-radius.

I looked in the closed issue and I saw that you had never upgraded since this issue 2212. It might be some reason but I thought it was convegnant to create an attribute in the button that allow users to generate a vml button for outlook directly in mjml without mj-raw.

In this PR I just implemented another render function for the button (also fixed a mistaken align)
I added three attributes { mso-proof (boolean), mso-width, mso-height }.

The default behaviour is unchanged so it's backward compatible.

Test code:
```
<mjml>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-button font-family="verdana" border="2px solid #ccc000" mso-proof="true" border-radius="20px" background-color="#f45e43" color="white">
          Don't click me!
         </mj-button>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

