### PR TITLE
[Update] Slack API is deprecated, use link instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ A free-to-use MJML API is available to make it easy to integrate MJML in your ap
 
 # MJML Slack
 
-MJML wouldn't be as cool without its amazing community. Head over the [Community Slack](https://slack.mjml.io/) to meet fellow MJML'ers.
+MJML wouldn't be as cool without its amazing community. Head over the [Community Slack](https://join.slack.com/t/mjml/shared_invite/zt-gqmwfwmr-kPBnfuuB7wof5httaTcXxg) to meet fellow MJML'ers.
 
 # Contributors
 

--- a/packages/mjml/README.md
+++ b/packages/mjml/README.md
@@ -139,4 +139,4 @@ A free-to-use MJML API is available to make it easy to integrate MJML in your ap
 
 # MJML Slack
 
-MJML wouldn't be as cool without its amazing community. Head over the [Community Slack](https://slack.mjml.io/) to meet fellow MJML'ers.
+MJML wouldn't be as cool without its amazing community. Head over the [Community Slack](https://join.slack.com/t/mjml/shared_invite/zt-gqmwfwmr-kPBnfuuB7wof5httaTcXxg) to meet fellow MJML'ers.

--- a/readme-ja.md
+++ b/readme-ja.md
@@ -184,12 +184,12 @@ console.log(htmlOutput)
 
 ## API
 
-無料のMJML APIを利用することで、あなたのアプリケーションにMJMLを簡単に統合できます。  
+無料のMJML APIを利用することで、あなたのアプリケーションにMJMLを簡単に統合できます。
 APIの詳細については[ここ](https://mjml.io/api)をご覧ください。
 
 # MJML Slack
 
-MJMLはその素晴らしいコミュニティなくしてはここまで良いものにならなかったでしょう。[コミュニティ Slack](https://slack.mjml.io/)から、MJML'er達に会いにいきましょう。
+MJMLはその素晴らしいコミュニティなくしてはここまで良いものにならなかったでしょう。[コミュニティ Slack](https://join.slack.com/t/mjml/shared_invite/zt-gqmwfwmr-kPBnfuuB7wof5httaTcXxg)から、MJML'er達に会いにいきましょう。
 
 # 貢献者
 


### PR DESCRIPTION
Website isn't updated yet but at least let's update the readme to use Slack invit links