### PR TITLE
components_2.md_for_mj-include

### DIFF
--- a/doc/components_2.md
+++ b/doc/components_2.md
@@ -1,7 +1,8 @@
 ## mj-include
 
-The `mjml-core` package allows you to include external `mjml` files
-  to build your email template.
+The `mjml-core` package adds `mj-include` content to
+  a copy of your MJML markup in memory.
+It uses that copy to build the HTML file.
 
 ```xml
 <!-- header.mjml -->
@@ -12,10 +13,6 @@ The `mjml-core` package allows you to include external `mjml` files
 </mj-section>
 ```
 
-You can wrap your external mjml files inside the default `mjml > mj-body`
-  tags to make it easier to preview outside the main template.
-
-
 ```xml
 <!-- main.mjml -->
 <mjml>
@@ -25,14 +22,29 @@ You can wrap your external mjml files inside the default `mjml > mj-body`
 </mjml>
 ```
 
+The `main.mjml` code here demonstrates adding content from `header.mjml`.
 
-The `MJML` engine will then replace your included files before starting the rendering process.
+The `header.mjml` code here is an include file without `mjml`, `mj-head`, and
+  `mj-body` tags.
+In this case, MJML puts all text from this file where
+  it finds the `mj-include`.
+
+MJML also allows the `mjml`, `mj-head`, and `mj-body` tags in include files.
+The resulting MJML include file can preview better outside the main template.
+When the main `mj-body` section holds these mixed include files,
+  MJML puts content of
+  (1) the `mj-head` from `mj-include` in the main `mj-head` element and 
+  (2) the `mj-body` from `mj-include` where it finds the `mj-include`.
+
+Include files can have `mj-include` elements.
+
 
 ### Other file types
 
-You can include external `css` files. They will be inserted the same way as when using a `mj-style`.  
-You need to specify that you're including a css file using the `type="css"` attribute.  
-If you want the css to be inlined, you can use the `css-inline="inline"` attribute.
+MJML can include external `css` files;
+  it inserts them as if finding an `mj-style`.  
+When including a CSS file, use the `type="css"` attribute.  
+The `css-inline="inline"` attribute causes MJML to inline the CSS.
 
 ```xml
 <!-- main.mjml -->
@@ -40,8 +52,10 @@ If you want the css to be inlined, you can use the `css-inline="inline"` attribu
   <mj-include path="./inline-styles.css" type="css" css-inline="inline" />
 ```
 
-You can also include external `html` files. They will be inserted the same way as when using a `mj-raw`.  
-You need to specify that you're including a html file using the `type="html"` attribute.  
+MJML can include external `html` files;
+  it inserts them as if finding an `mj-raw`.  
+When including an HTML file, use the `type="html"` attribute.
+MJML puts the external HTML where it finds the `<include>`.
 
 ```xml
 <!-- main.mjml -->


### PR DESCRIPTION
### components_2.md_for_mj-include

Some time ago, I opened PR #2033, about documentation for `mj-include`. I recently closed it.

In discussion, some ideas were somehow lost. This re-introduces some of those.

Some ideas in #2033 needed to come out; they're gone.

Valuable new capability for "mj-include" has since been added. Related documentation needed to stay. It did.

I found ways to change the expression in minor ways to make the text "more difficult to misunderstand", a different thing than "possible to understand".

For example, active voice is often shorter and more direct than passive voice in technical writing. I changed some without changing sentence meaning.

I changed "a" to "an" a couple of places.

"MJML", "HTML", and "CSS" are more specific and traditional (in text) than their lower-case equivalents. (Doesn't apply to code.)

I removed reference to "rendering", which referred here to MJML's compilation to HTML.

Almost all the above changes shortened the text.

I mean no offense in any changes. I could well be changing my own previous text here.

I added a little text, believing it adds clarity. You will not surprise me to consider it too wordy. I include it only in case I misread you.