### PR TITLE
Chad/202106 mjml default color fix

### DIFF
--- a/packages/mjml-core/src/types/color.js
+++ b/packages/mjml-core/src/types/color.js
@@ -21,7 +21,7 @@ export default () =>
     }
 
     getValue() {
-      if (this.value.match(shorthandRegex)) {
+      if (typeof this.value === 'string' && this.value.match(shorthandRegex)) {
         return this.value.replace(replaceInputRegex, replaceOutput)
       }
 

--- a/packages/mjml-core/src/types/helpers/colors.js
+++ b/packages/mjml-core/src/types/helpers/colors.js
@@ -60,6 +60,7 @@ export default [
   'hotpink',
   'indianred',
   'indigo',
+  'inherit',
   'ivory',
   'khaki',
   'lavender',


### PR DESCRIPTION
Adds "inherit" as a valid color prop, and adds a type guard on the color validator to avoid crashes when color props are not set 