### PR TITLE
packages/mjml-hero/README.md, remove: "width"

### DIFF
--- a/packages/mjml-hero/README.md
+++ b/packages/mjml-hero/README.md
@@ -119,4 +119,3 @@ padding-left        | px                                  | left offset         
 padding-right       | px                                  | right offset                                                         | 0px
 padding-top         | px                                  | top offset                                                           | 0px
 vertical-align      | top/middle/bottom                   | content vertical alignment                                           | top
-width               | px                                  | hero container width                                                 | parent element width


### PR DESCRIPTION
### Change
In packages/mjml-hero/README.md, remove the entry in the attributes table for "width".

PR motivated by discussion at https://mjml.slack.com/archives/C12HPPHG8/p1630753983002500