### PR TITLE
CVE-2021-3803 Upgrade nth-check to 2.0.1 from 2.0.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6250,9 +6250,9 @@ npmlog@^4.1.2:
     set-blocking "~2.0.0"
 
 nth-check@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.0.tgz#1bb4f6dac70072fc313e8c9cd1417b5074c0a125"
-  integrity sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
 


### PR DESCRIPTION
Can you please consider upgrade nth-check from 2.0.0 to 2.0.1 because of this vulnerability https://github.com/advisories/GHSA-rp65-9cf3-cjxr

I know it is painful to address all these not relevant to mjml vulnerabilities. So I created the PR to make your life easier

It would be great if you can merge this to master & do a version release

Thank you