### PR TITLE
Allow height auto settings for mjml-text

### DIFF
--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -16,7 +16,7 @@ export default class MjText extends BodyComponent {
     'font-size': 'unit(px)',
     'font-style': 'string',
     'font-weight': 'string',
-    height: 'unit(px,%)',
+    height: 'unit(px,%,auto)',
     'letter-spacing': 'unitWithNegative(px,em)',
     'line-height': 'unit(px,%,)',
     'padding-bottom': 'unit(px,%)',


### PR DESCRIPTION
height should not throw a warning when setted to auto