### PR TITLE
delete mj-image doc width 100%

### DIFF
--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -50,4 +50,4 @@ srcset                        | url & width   | enables to set a different image
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
 usemap                        | string        | reference to image map, be careful, it isn't supported everywhere         | n/a
-width                         | px            | image width                    | 100%
+width                         | px            | image width                    | n/a

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -50,4 +50,4 @@ srcset                        | url & width   | enables to set a different image
 target                        | string        | link target on click           | \_blank
 title                         | string        | tooltip & accessibility        | n/a
 usemap                        | string        | reference to image map, be careful, it isn't supported everywhere         | n/a
-width                         | px            | image width                    | n/a
+width                         | px            | image width                    | parent width


### PR DESCRIPTION
Earlier today, Kajsa Eklöf suggested the "width" line of the documentation for mj-image is confusing

width                         | px            | image width                    | 100%

(The attribute only allows px, but the default is in percent.)

This will change the line to

width                         | px            | image width                    | n/a

In case that's how you want to respond ...