### PR TITLE
fix watch on non mjml includes

### DIFF
--- a/packages/mjml-cli/src/commands/watchFiles.js
+++ b/packages/mjml-cli/src/commands/watchFiles.js
@@ -22,8 +22,6 @@ const flatMapKeyAndValues = flow(
 )
 
 export default (input, options) => {
-  console.log(`Now watching: ${input}`)
-
   const dependencies = {}
   const outputToFile = makeOutputToFile(options.o)
   const getRelatedFiles = (file) =>
@@ -97,6 +95,7 @@ export default (input, options) => {
     .on('change', (file) => synchronyzeWatcher(path.resolve(file)))
     .on('add', (file) => {
       const filePath = path.resolve(file)
+      console.log(`Now watching file: ${filePath}`)
 
       const matchInputOption = input.reduce(
         (found, file) =>

--- a/packages/mjml-cli/src/helpers/fileContext.js
+++ b/packages/mjml-cli/src/helpers/fileContext.js
@@ -1,10 +1,11 @@
 import fs from 'fs'
 import path from 'path'
 
-const includeRegexp = /<mj-include\s+path=['"](.*[.mjml]?)['"]\s*(\/>|>\s*<\/mj-include>)/g
+const includeRegexp = /<mj-include\s+path=['"](.*(?:\.mjml|\.css|\.html))['"]\s*[^<>]*(\/>|>\s*<\/mj-include>)/gi
 
-const ensureIncludeIsMJMLFile = (file) =>
-  (file.trim().match(/.mjml/) && file) || `${file}.mjml`
+const ensureIncludeIsSupportedFile = (file) => 
+  path.extname(file).match(/\.mjml|\.css|\.html/) ? file : `${file}.mjml`
+  
 const error = (e) => console.error(e.stack || e) // eslint-disable-line no-console
 
 export default (baseFile, filePath) => {
@@ -28,8 +29,8 @@ export default (baseFile, filePath) => {
   const readIncludes = (dir, file, base) => {
     const currentFile = path.resolve(
       dir
-        ? path.join(dir, ensureIncludeIsMJMLFile(file))
-        : ensureIncludeIsMJMLFile(file),
+        ? path.join(dir, ensureIncludeIsSupportedFile(file))
+        : ensureIncludeIsSupportedFile(file),
     )
 
     const currentDirectory = path.dirname(currentFile)
@@ -46,7 +47,7 @@ export default (baseFile, filePath) => {
 
     let matchgroup = includes.exec(content)
     while (matchgroup != null) {
-      const includedFile = ensureIncludeIsMJMLFile(matchgroup[1])
+      const includedFile = ensureIncludeIsSupportedFile(matchgroup[1])
 
       // when reading first level of includes we must join the path specified in filePath
       // when reading further nested includes, just take parent dir as base


### PR DESCRIPTION
Changed regex so that 
- css and html files are also accepted
- other html attributes on mj-include (like `type="css"`) won't prevent the regex from matching

Added a "Now watching:" log for included files too, so that the user knows these files are watched