### PR TITLE
ref #2344 expose mjml file path in components props

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -54,9 +54,11 @@ class Component {
       context = {},
       props = {},
       globalAttributes = {},
+      absoluteFilePath = null,
     } = initialDatas
 
     this.props = {
+      absoluteFilePath,
       ...props,
       children,
       content,


### PR DESCRIPTION
allow to access to the mjml file path in this.props
@iRyusa i know you suggested using globalDatas, but absoluteFilePath is already available in the initialDatas of every component, and we need to handle the case of mj-included files, so it seemed simpler this way