### PR TITLE
Add text-align="center" to doc example

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -51,7 +51,8 @@ First, we will implement the skeleton which are the sections. Here, our email is
 <!-- Company Header -->
 <mj-section background-color="#f0f0f0">
   <mj-column>
-    <mj-text  font-style="italic"
+    <mj-text  align="center"
+	      font-style="italic"
               font-size="20px"
               color="#626262">
       My Company
@@ -77,11 +78,12 @@ The text padding represents the inner space around the content within the `mj-te
               background-repeat="no-repeat">
 
     <mj-column width="600px">
-
-		  <mj-text  align="center"
-                color="#fff"
-                font-size="40px"
-                font-family="Helvetica Neue">Slogan here</mj-text>
+	<mj-text  align="center"
+                  color="#fff"
+                  font-size="40px"
+                  font-family="Helvetica Neue">
+	  Slogan here
+	</mj-text>
 
       <mj-button background-color="#F63A4D"
                  href="#">


### PR DESCRIPTION
Just 2 quick changes:

- Added text-align="center" to doc example since the [image](https://documentation.mjml.io/#basic-layout-example) shows it centered and the [doc itself](https://documentation.mjml.io/#company-header) says  "The first section of the email consists in a centered banner".

- Fixed some formatting  directly below

The [Live example](https://mjml.io/try-it-live/P16bj5WQT) will also have to be updated but I'm not sure how to go about changing that.