### PR TITLE
Fix overlapping max-width and min-width on media queries

### DIFF
--- a/packages/mjml-core/src/helpers/makeLowerBreakpoint.js
+++ b/packages/mjml-core/src/helpers/makeLowerBreakpoint.js
@@ -1,0 +1,8 @@
+export default function makeLowerBreakpoint(breakpoint) {
+  try {
+    const pixels = Number.parseInt(breakpoint.match('[0-9]+')[0], 10)
+    return `${pixels - 1}px`
+  } catch (e) {
+    return breakpoint
+  }
+}

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -29,6 +29,7 @@ import globalComponents, {
   assignComponents,
 } from './components'
 
+import makeLowerBreakpoint from './helpers/makeLowerBreakpoint'
 import suffixCssClasses from './helpers/suffixCssClasses'
 import mergeOutlookConditionnals from './helpers/mergeOutlookConditionnals'
 import minifyOutlookConditionnals from './helpers/minifyOutlookConditionnals'
@@ -422,6 +423,7 @@ export {
   initComponent,
   registerComponent,
   assignComponents,
+  makeLowerBreakpoint,
   suffixCssClasses,
   handleMjmlConfig,
   initializeType,

--- a/packages/mjml-head-breakpoint/README.md
+++ b/packages/mjml-head-breakpoint/README.md
@@ -1,5 +1,5 @@
 ## mj-breakpoint
-This tag allows you to control on which breakpoint the layout should go desktop/mobile.
+This tag allows you to control on which breakpoint the layout should go desktop/mobile. At window widths below this value the layout will be displayed in mobile mode.
 
 ```xml
 <mjml>

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -1,6 +1,6 @@
 import { min } from 'lodash'
 
-import { BodyComponent } from 'mjml-core'
+import { BodyComponent, makeLowerBreakpoint } from 'mjml-core'
 
 import widthParser from 'mjml-core/lib/helpers/widthParser'
 
@@ -133,7 +133,7 @@ export default class MjImage extends BodyComponent {
   }
 
   headStyle = (breakpoint) => `
-    @media only screen and (max-width:${breakpoint}) {
+    @media only screen and (max-width:${makeLowerBreakpoint(breakpoint)}) {
       table.mj-full-width-mobile { width: 100% !important; }
       td.mj-full-width-mobile { width: auto !important; }
     }

--- a/packages/mjml-navbar/src/Navbar.js
+++ b/packages/mjml-navbar/src/Navbar.js
@@ -1,4 +1,4 @@
-import { BodyComponent } from 'mjml-core'
+import { BodyComponent, makeLowerBreakpoint } from 'mjml-core'
 import crypto from 'crypto'
 
 import conditionalTag, {
@@ -53,7 +53,7 @@ export default class MjNavbar extends BodyComponent {
     `
       noinput.mj-menu-checkbox { display:block!important; max-height:none!important; visibility:visible!important; }
 
-      @media only screen and (max-width:${breakpoint}) {
+      @media only screen and (max-width:${makeLowerBreakpoint(breakpoint)}) {
         .mj-menu-checkbox[type="checkbox"] ~ .mj-inline-links { display:none!important; }
         .mj-menu-checkbox[type="checkbox"]:checked ~ .mj-inline-links,
         .mj-menu-checkbox[type="checkbox"] ~ .mj-menu-trigger { display:block!important; max-width:none!important; max-height:none!important; font-size:inherit!important; }


### PR DESCRIPTION
The configured breakpoint is being used in the css media queries for the desktop `(min-width: breakpoint)` and mobile `(max-width: breakpoint)`. This causes the queries to overlap at the exact breakpoint size, e.g. 700px, and being active at the same time.

These changes reduce the mobile breakpoint to `(max-width: breakpoint-1)`, so that the set breakpoint represents the smallest width for the desktop layout.