### PR TITLE
MJML3--time to remove reference to it?

### DIFF
--- a/doc/create.md
+++ b/doc/create.md
@@ -3,5 +3,3 @@
 One of the great advantages of `MJML` is that it's component-based. Components abstract complex patterns and can easily be reused. In addition to the standard library of components, it is also possible to create your own components!
 
 We have published a step-by-step guide [here](https://medium.com/mjml-making-responsive-email-easy/tutorial-creating-your-own-component-with-mjml-4-1c0e84e97b36) that explains how to create a custom components with `MJML 4`. It will introduce to you the [boilerplate repo](https://github.com/mjmlio/mjml-component-boilerplate) hosted on Github, which provides a fast way of getting started developing your own components.
-
-Read the guide to creating custom components for MJML 3 [here](https://medium.com/mjml-making-responsive-email-easy/tutorial-creating-your-own-mjml-component-d3a236ab7093#.pz0ebb537) (note that it won't be compatible with `MJML 4`).


### PR DESCRIPTION
Someday, perhaps we'll want to stop referring to MJML 3 in our documentation.

Maybe today's the day?

I know of this one reference. If there are others, I'm happy to include them in this change.