### PR TITLE
Support width="auto" on mj-column

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -27,7 +27,7 @@ export default class MjColumn extends BodyComponent {
     'inner-border-top': 'string',
     padding: 'unit(px,%){1,4}',
     'vertical-align': 'enum(top,bottom,middle)',
-    width: 'unit(px,%)',
+    width: 'unit(px,%,auto)',
   }
 
   static defaultAttributes = {
@@ -122,6 +122,9 @@ export default class MjColumn extends BodyComponent {
     const width = this.getAttribute('width')
     const mobileWidth = this.getAttribute('mobileWidth')
 
+    if (width === 'auto') {
+      return width
+    }
     if (mobileWidth !== 'mobileWidth') {
       return '100%'
     }
@@ -149,6 +152,9 @@ export default class MjColumn extends BodyComponent {
       parseFloatToInt: false,
     })
 
+    if (unit === 'auto') {
+      return unit
+    }
     if (unit === '%') {
       return `${(parseFloat(containerWidth) * parsedWidth) / 100}px`
     }
@@ -183,6 +189,9 @@ export default class MjColumn extends BodyComponent {
     const formattedClassNb = parsedWidth.toString().replace('.', '-')
 
     switch (unit) {
+      case 'auto':
+        return 'mj-column-auto'
+
       case '%':
         className = `mj-column-per-${formattedClassNb}`
         break

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -72,7 +72,7 @@ export default class MjImage extends BodyComponent {
         'font-size': this.getAttribute('font-size'),
       },
       td: {
-        width: fullWidth ? null : `${parsedWidth}${unit}`,
+        width: fullWidth || width === Infinity ? null : `${parsedWidth}${unit}`,
       },
       table: {
         'min-width': fullWidth ? '100%' : null,
@@ -96,6 +96,7 @@ export default class MjImage extends BodyComponent {
 
   renderImage() {
     const height = this.getAttribute('height')
+    const width = this.getContentWidth()
 
     const img = `
       <img
@@ -107,7 +108,7 @@ export default class MjImage extends BodyComponent {
           sizes: this.getAttribute('sizes'),
           style: 'img',
           title: this.getAttribute('title'),
-          width: this.getContentWidth(),
+          width: width === Infinity ? null : width,
           usemap: this.getAttribute('usemap'),
         })}
       />


### PR DESCRIPTION
Addresses #2144 

Code used to test:

```
<mjml>
  <mj-body>
    <mj-section>
      <mj-column width="250px" background-color="blue">
        <mj-button>250px</mj-button>
      </mj-column>
      <mj-column width="auto" background-color="red">
        <mj-button>auto</mj-button>
      </mj-column>
      <mj-column width="auto" background-color="yellow">
        <mj-image src="https://mjml.io/assets/img/logo-small.png" />
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

Tested in:
Outlook 365
Outlook 2007
![image](https://user-images.githubusercontent.com/2874325/165868356-9f6b3063-e86d-46fc-81b6-9afc25c18449.png)
Gmail
![image](https://user-images.githubusercontent.com/2874325/165868463-7d323e1f-9fee-43e0-b05f-9e985bb50f3c.png)
Yahoo webmail
![image](https://user-images.githubusercontent.com/2874325/165868488-4e1de63f-b5e5-4f34-b765-254b75a42d86.png)
Outlook webmail
![image](https://user-images.githubusercontent.com/2874325/165868447-c4a73385-22dc-44a5-8cda-716a99469cd5.png)
