### PR TITLE
Add doc for mjml-chartjs community component

### DIFF
--- a/doc/config.json
+++ b/doc/config.json
@@ -34,6 +34,7 @@
   "mjml/doc/ending-tags.md",
   "mjml/doc/community-components.md",
   "mjml/doc/mjml-chart.md",
+  "mjml/doc/mjml-chartjs.md",
   "mjml/doc/mjml-qr-code.md",
   "mjml/doc/mjml-mso-button.md",
   "mjml/packages/mjml-validator/README.md",

--- a/doc/mjml-chartjs.md
+++ b/doc/mjml-chartjs.md
@@ -1,0 +1,10 @@
+## mj-chartjs
+
+This component displays [Chart.js](https://www.chartjs.org/) charts as images in your email.  Chart.js is an open-source Javascript charting library.
+
+mj-chartjs is available on [Github](https://github.com/typpo/mjml-chartjs) and [NPM](https://www.npmjs.com/package/mjml-chartjs).  By default, it uses the open-source [QuickChart](https://quickchart.io/) API for chart rendering.
+
+<p style="text-align: center;" >
+  <img src="https://quickchart.io/chart?c=%7B%0A%20%20%20%20%20%20%20%20%20%20type%3A%20%27bar%27%2C%0A%20%20%20%20%20%20%20%20%20%20data%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20labels%3A%20%5B%27Q1%27%2C%20%27Q2%27%2C%20%27Q3%27%2C%20%27Q4%27%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20datasets%3A%20%5B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20label%3A%20%27Users%27%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20data%3A%20%5B50%2C%2060%2C%2070%2C%20180%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20backgroundColor%3A%20%27rgb(75%2C%20192%2C%20192)%27%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%5D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20&w=500&h=300&bkg=%23ffffff&v=3&devicePixelRatio=1" alt="mj-chartjs demo" />
+</p>
+


### PR DESCRIPTION
This mjml component allows the user to embed Chart.js chart images in email:

- Github: https://github.com/typpo/mjml-chartjs
- npm: https://www.npmjs.com/package/mjml-chartjs

Charts in email are useful for reporting, analytics, etc.

The component uses [QuickChart](https://github.com/typpo/quickchart), which is open-source and can be self-hosted. It supports a host attribute so users can point to a custom renderer if desired.

Here's a very basic example:

```
<mjml>
  <mj-body>
    <mj-section>
      <mj-text align="center">
        Here's the latest data:
      </mj-text>
    </mj-section>
    <mj-section>
      <mj-column align="center">
        <mj-chartjs align="center" chart="{
          type: 'bar',
          data: {
            labels: ['Q1', 'Q2', 'Q3', 'Q4'],
            datasets: [{
              label: 'Users',
              data: [50, 60, 70, 180],
              backgroundColor: 'rgb(75, 192, 192)',
            }]
          }
        }
        " />
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

![mjml chart render](https://user-images.githubusercontent.com/310310/175119105-7954411b-8bc3-49a3-9295-8b4ea36dda10.png)