### PR TITLE
Fix doc about the `fonts` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can pass optional `options` as an object to the `mjml2html` function:
 
 option   | unit   | description  | default value
 -------------|--------|--------------|---------------
-fonts  | object | Default fonts imported in the HTML rendered by HTML | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L36-L44)
+fonts  | object | Default fonts imported in the HTML rendered by MJML | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L100-L108)
 keepComments | boolean | Option to keep comments in the HTML output | true
 ignoreIncludes | boolean | Option to ignore mj-includes | false
 beautify | boolean | Option to beautify the HTML output | false

--- a/doc/install.md
+++ b/doc/install.md
@@ -100,7 +100,7 @@ You can pass optional `options` as an object to the `mjml2html` function:
 
 option                  | unit      | description                                                                                                                                               | default value
 ----------------------- |---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |---------------
-fonts                   | object    | Default fonts imported in the HTML rendered by HTML                                                                                                       | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L36-L44)
+fonts                   | object    | Default fonts imported in the HTML rendered by MJML                                                                                                       | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L100-L108)
 keepComments            | boolean   | Option to keep comments in the HTML output                                                                                                                | true
 beautify                | boolean   | Option to beautify the HTML output                                                                                                                        | false
 minify                  | boolean   | Option to minify the HTML output                                                                                                                          | false

--- a/packages/mjml/README.md
+++ b/packages/mjml/README.md
@@ -120,7 +120,7 @@ You can pass optional `options` as an object to the `mjml2html` function:
 
 option   | unit   | description  | default value
 -------------|--------|--------------|---------------
-fonts  | object | Default fonts imported in the HTML rendered by HTML | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L36-L44)
+fonts  | object | Default fonts imported in the HTML rendered by MJML | See in [index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L100-L108)
 keepComments | boolean | Option to keep comments in the HTML output | true
 ignoreIncludes | boolean | Option to ignore mj-includes | false
 beautify | boolean | Option to beautify the HTML output | false

--- a/readme-ja.md
+++ b/readme-ja.md
@@ -140,7 +140,7 @@ console.log(htmlOutput)
 
 オプション   | 型   | 説明  | 初期値
 -------------|--------|--------------|---------------
-fonts  | object | 初期フォントをインポートしたHTMLを描画する | 初期フォントについては[index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L36-L44)をご覧ください。
+fonts  | object | 初期フォントをインポートしたHTMLを描画する | 初期フォントについては[index.js](https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L100-L108)をご覧ください。
 keepComments | boolean | 出力されるHTMLにコメントを残すオプション | true
 ignoreIncludes | boolean | mj-includesを無視するオプション | false
 beautify | boolean | 出力されるHTMLを整えるオプション | false


### PR DESCRIPTION
"the HTML rendered by HTML" was obviously not intended.
I guessed "the HTML rendered by MJML" was meant.

Also, the lines 36-44 with the `fonts` default value started to moved two years ago and are now much further down: https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js#L100-L108