### PR TITLE
Documentation (Ports) - MJML.NET Details Updated

### DIFF
--- a/doc/ports.md
+++ b/doc/ports.md
@@ -22,7 +22,6 @@ https://github.com/SebastianStehle/mjml-net
 ### Missing implementations / components
 
 - `mj-style[inline]`: not yet implemented for performance reasons.
-- `mj-include`: not yet implemented because the library is used by server applications where the template is stored in the database.
 - `mj-html-attributes`: not yet implemented for performance reasons.
 
 ## Elixir: MJML (Rust NIFs for Elixir)


### PR DESCRIPTION
MJML.NET now supports `<mj-include>` this change reflects the latest update by removing the existing point in the documentation regarding `<mj-include>` not being supported.