### PR TITLE
Fixed the unclickable area in MSO-PC for the buttons

### DIFF
--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -7,23 +7,6 @@
 
 Displays a customizable button.
 
-<aside style="text-decoration: line-through">
-  The `mj-button` won't be fully clickable because of client support.
-  See discussion at
-    <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a>.
-</aside>
-<br>
-<aside class="notice">
-Notes for the Fixed previous <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a> in discussion at <a href="https://github.com/mjmlio/mjml/issues/2565">Issue #2565</a>
-  <ul>
-    <li style="padding-bottom: 8px"><strong>in getStyles.td:</strong><br>Removed the mso-padding-alt as inner padding cause is no longer needed when the size of the button is controlled by the padding in the anchor. If I keep the MSO-attribute, the button will be shown as twice the size in MSO-PC.</li>
-    <li style="padding-bottom: 8px"><strong>in getStyles.content:</strong><br>
-    Removed the mso-padding-alt: 0px cause is nullifying the effect of activating the anchor as a button in MSO-PC. The padding in the anchor is now effectively creating the internal size of the button.</li>
-    <li style="padding-bottom: 8px"><strong>Added border:</strong><br>1px solid which activates a "bug" in MSO-PC, forcing MSO to read the display attribute of the button (default: inline-block) and thus, changing the behavior of the anchor in MSO to act like a common anchor in all the other readers/browsers.</li>
-    <li style="padding-bottom: 8px">To avoid non-corresponding colours between the background of the container TD and the border created in the anchor, I added the this.getAttribute('background-color') property to the style, aligning both colours, minimizing the unwilling mismatching.</li>
-  </ul>
-</aside>
-
 ```xml
 <mjml>
   <mj-body>

--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -7,10 +7,21 @@
 
 Displays a customizable button.
 
-<aside class="notice">
+<aside style="text-decoration: line-through">
   The `mj-button` won't be fully clickable because of client support.
   See discussion at
     <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a>.
+</aside>
+<br>
+<aside class="notice">
+Notes for the Fixed previous <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a> in discussion at <a href="https://github.com/mjmlio/mjml/issues/2565">Issue #2565</a>
+  <ul>
+    <li style="padding-bottom: 8px"><strong>in getStyles.td:</strong><br>Removed the mso-padding-alt as inner padding cause is no longer needed when the size of the button is controlled by the padding in the anchor. If I keep the MSO-attribute, the button will be shown as twice the size in MSO-PC.</li>
+    <li style="padding-bottom: 8px"><strong>in getStyles.content:</strong><br>
+    Removed the mso-padding-alt: 0px cause is nullifying the effect of activating the anchor as a button in MSO-PC. The padding in the anchor is now effectively creating the internal size of the button.</li>
+    <li style="padding-bottom: 8px"><strong>Added border:</strong><br>1px solid which activates a "bug" in MSO-PC, forcing MSO to read the display attribute of the button (default: inline-block) and thus, changing the behavior of the anchor in MSO to act like a common anchor in all the other readers/browsers.</li>
+    <li style="padding-bottom: 8px">To avoid non-corresponding colours between the background of the container TD and the border created in the anchor, I added the this.getAttribute('background-color') property to the style, aligning both colours, minimizing the unwilling mismatching.</li>
+  </ul>
 </aside>
 
 ```xml

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -97,7 +97,7 @@ export default class MjButton extends BodyComponent {
         'text-decoration': this.getAttribute('text-decoration'),
         'text-transform': this.getAttribute('text-transform'),
         padding: this.getAttribute('inner-padding'),
-        //'mso-padding-alt': '0px',
+        // 'mso-padding-alt': '0px',
         border: this.getAttribute('background-color') + ' 1px solid',
         'border-radius': this.getAttribute('border-radius'),
       },
@@ -127,36 +127,36 @@ export default class MjButton extends BodyComponent {
     return `
       <table
         ${this.htmlAttributes({
-          border: '0',
-          cellpadding: '0',
-          cellspacing: '0',
-          role: 'presentation',
-          style: 'table',
-        })}
+      border: '0',
+      cellpadding: '0',
+      cellspacing: '0',
+      role: 'presentation',
+      style: 'table',
+    })}
       >
         <tbody>
           <tr>
             <td
               ${this.htmlAttributes({
-                align: 'center',
-                bgcolor:
-                  this.getAttribute('background-color') === 'none'
-                    ? undefined
-                    : this.getAttribute('background-color'),
-                role: 'presentation',
-                style: 'td',
-                valign: this.getAttribute('vertical-align'),
-              })}
+      align: 'center',
+      bgcolor:
+        this.getAttribute('background-color') === 'none'
+          ? undefined
+          : this.getAttribute('background-color'),
+      role: 'presentation',
+      style: 'td',
+      valign: this.getAttribute('vertical-align'),
+    })}
             >
               <${tag}
                 ${this.htmlAttributes({
-                  href: this.getAttribute('href'),
-                  name: this.getAttribute('name'),
-                  rel: this.getAttribute('rel'),
-                  title: this.getAttribute('title'),
-                  style: 'content',
-                  target: tag === 'a' ? this.getAttribute('target') : undefined,
-                })}
+      href: this.getAttribute('href'),
+      name: this.getAttribute('name'),
+      rel: this.getAttribute('rel'),
+      title: this.getAttribute('title'),
+      style: 'content',
+      target: tag === 'a' ? this.getAttribute('target') : undefined,
+    })}
               >
                 ${this.getContent()}
               </${tag}>

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -78,7 +78,7 @@ export default class MjButton extends BodyComponent {
         cursor: 'auto',
         'font-style': this.getAttribute('font-style'),
         height: this.getAttribute('height'),
-        'mso-padding-alt': this.getAttribute('inner-padding'),
+        // 'mso-padding-alt': this.getAttribute('inner-padding'),
         'text-align': this.getAttribute('text-align'),
         background: this.getAttribute('background-color'),
       },
@@ -97,7 +97,8 @@ export default class MjButton extends BodyComponent {
         'text-decoration': this.getAttribute('text-decoration'),
         'text-transform': this.getAttribute('text-transform'),
         padding: this.getAttribute('inner-padding'),
-        'mso-padding-alt': '0px',
+        //'mso-padding-alt': '0px',
+        border: this.getAttribute('background-color') + ' 1px solid',
         'border-radius': this.getAttribute('border-radius'),
       },
     }


### PR DESCRIPTION
Notes for the previous <a href="https://github.com/mjmlio/mjml/issues/359">Issue #359</a> fixed here, following the discussion at <a href="https://github.com/mjmlio/mjml/issues/2565">Issue #2565</a>

### In getStyles.td:
Removed the mso-padding-alt as inner padding cause is no longer needed when the size of the button is controlled by the padding in the anchor. If I keep the MSO-attribute, the button will be shown as twice the size in MSO-PC.

### in getStyles.content:
Removed the mso-padding-alt: 0px cause is nullifying the effect of activating the anchor as a button in MSO-PC. The padding in the anchor is now effectively creating the internal size of the button.

### Added border:
1px solid which activates a "bug" in MSO-PC, forcing MSO to read the display attribute of the button (default: inline-block) and thus, changing the behavior of the anchor in MSO to act like a common anchor in all the other readers/browsers.

To avoid non-corresponding colours between the background of the container TD and the border created in the anchor, I added the this.getAttribute('background-color') property to the style, aligning both colours, minimizing the unwilling mismatching.

### Results in MSO-PC
![OUTLOOK_XV0ASQ3Yp9](https://user-images.githubusercontent.com/742912/205295448-c81e9c80-8596-440d-9806-514f9922cda2.png)


### Tested in EoA:
![msedge_LmhK6iasyn](https://user-images.githubusercontent.com/742912/205295703-4556b9db-fa50-4d97-ad26-9e1b3483586f.png)

![msedge_vFvHRbUEhY](https://user-images.githubusercontent.com/742912/205295755-0604694b-fd27-4eeb-b87f-f01cd0052831.png)

![msedge_GJFkN9eRU4](https://user-images.githubusercontent.com/742912/205295799-c90db8fa-1358-4510-b0b5-8e8ff783a100.png)

![msedge_dmll9qjS51](https://user-images.githubusercontent.com/742912/205295858-d74f5935-916a-46c1-aa8d-36ebc236e0ff.png)

![msedge_NvHu4RHSal](https://user-images.githubusercontent.com/742912/205295909-7f9a8c73-9178-4009-8a59-94a87a723667.png)

### Tested in Litmus
![msedge_y3YeP1cyMR](https://user-images.githubusercontent.com/742912/205296308-7d6aa27f-ad69-45f8-8510-233144e3b3c9.png)

![msedge_yKEEjAEX4a](https://user-images.githubusercontent.com/742912/205297308-419bad39-be95-4b4c-9285-25803d21bbab.png)

![msedge_yKEEjAEX4a](https://user-images.githubusercontent.com/742912/205297867-0fb0dc2f-b8f6-4269-9168-cb5bd673f06f.png)

