### PR TITLE
Update useMjmlConfigOptions doc description

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ preprocessors | array of functions | Preprocessors applied to the xml before par
 juicePreserveTags | Preserve some tags when inlining css, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info | NA
 minifyOptions | Options for html minifier, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info | NA
 mjmlConfigPath | string | The path or directory of the `.mjmlconfig` file (for custom components use) | `process.cwd()`
-useMjmlConfigOptions | Allows to use the `config` attribute from `.mjmlconfig` file | false
+useMjmlConfigOptions | Allows to use the `options` attribute from `.mjmlconfig` file | false
 
 ## Client-side (in browser)
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -65,7 +65,7 @@ argument                                                | description           
 `mjml [input] --config.juicePreserveTags`               | Preserve some tags when inlining css, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info  | NA
 `mjml [input] --config.minifyOptions`                   | Options for html minifier, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info             | NA
 `mjml [input] --config.mjmlConfigPath [mjmlconfigPath]` | Uses the `.mjmlconfig` file in the specified path or directory to include custom components                                                               | *The `.mjmlconfig` file in the current working directory, if any*
-`mjml [input] --config.useMjmlConfigOptions`            | Allows to use the `config` attribute from `.mjmlconfig` file                                                                                              | false
+`mjml [input] --config.useMjmlConfigOptions`            | Allows to use the `options` attribute from `.mjmlconfig` file                                                                                              | false
 `mjml [input] --config.validationLevel`                 | [Validation level](https://github.com/mjmlio/mjml/tree/master/packages/mjml-validator#validating-mjml): 'strict', 'soft' or 'skip'                        | 'soft'
 
 ## Inside Node.js
@@ -107,7 +107,7 @@ minify                  | boolean   | Option to minify the HTML output          
 validationLevel         | string    | Available values for the [validator](https://github.com/mjmlio/mjml/tree/master/packages/mjml-validator#validating-mjml): 'strict', 'soft', 'skip'        | 'soft'
 filePath                | string    | Full path of the specified file to use when resolving paths from [`mj-include` components](#mj-include)                                                   | '.'
 mjmlConfigPath          | string    | The path or directory of the [`.mjmlconfig` file](#community-components)                                                                                  | `process.cwd()`
-useMjmlConfigOptions    | boolean   | Allows to use the `config` attribute from `.mjmlconfig` file                                                                                              | false
+useMjmlConfigOptions    | boolean   | Allows to use the `options` attribute from `.mjmlconfig` file                                                                                              | false
 minifyOptions           | object    | Options for html minifier, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info             | `{"collapseWhitespace": true, "minifyCSS": false, "removeEmptyAttributes": true}`
 juicePreserveTags       | boolean   | Optional setting when inlining css, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info    | NA
 

--- a/packages/mjml/README.md
+++ b/packages/mjml/README.md
@@ -131,7 +131,7 @@ preprocessors | array of functions | Preprocessors applied to the xml before par
 juicePreserveTags | Preserve some tags when inlining css, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info | NA
 minifyOptions | Options for html minifier, see [mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md) for more info | NA
 mjmlConfigPath | string | The path or directory of the `.mjmlconfig` file (for custom components use) | `process.cwd()`
-useMjmlConfigOptions | Allows to use the `config` attribute from `.mjmlconfig` file | false
+useMjmlConfigOptions | Allows to use the `options` attribute from `.mjmlconfig` file | false
 
 Note that it's also possible to define preprocessors in your mjmlconfig file. For this, you need to use a `.mjmlconfig.js` file. This js file needs to export an Object with the same structure as a standard JSON .mjmlconfig file.  
 

--- a/readme-ja.md
+++ b/readme-ja.md
@@ -151,7 +151,7 @@ preprocessors | array of functions | xmlのパース前に適用するプリプ�
 juicePreserveTags | cssをインライン化する際にタグを保持する。詳しくは[mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md)をご覧ください。 | NA
 minifyOptions | htmlのminify化に関するオプション。詳しくは[mjml-cli documentation](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md)をご覧ください。 | NA
 mjmlConfigPath | string | `.mjmlconfig`ファイルのパスもしくはディレクトリー(カスタムコンポーネントの場合) | `process.cwd()`
-useMjmlConfigOptions | `.mjmlconfig`ファイルで`config`属性の使用を許可する | false
+useMjmlConfigOptions | `.mjmlconfig`ファイルで`options`属性の使用を許可する | false
 
 ## クライアントサイド (ブラウザー)
 


### PR DESCRIPTION
Correctly reference `options` instead of `config` in `.mjmlconfig`.