### PR TITLE
style!: comment about removed atom hint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Don't want to install anything? Use the free online editor!
 MJML comes with an ecosystem of tools and plugins, check out:
 - The [MJML App](https://mjmlio.github.io/mjml-app/) (MJML is included)
 - [Visual Studio Code plugin](https://github.com/mjmlio/vscode-mjml) (MJML is included)
-- [Atom plugin](https://atom.io/users/mjmlio) (MJML needs to be installed separately)
 - [Sublime Text plugin](https://packagecontrol.io/packages/MJML-syntax) (MJML needs to be installed separately)
 
 For more tools, check the [Community](https://mjml.io/community) page.


### PR DESCRIPTION
It is no longer necessary to maintain the link to atom plugin, since it was officially archived.
More on this https://github.com/atom-archive