### PR TITLE
Update mjml-react home

### DIFF
--- a/doc/ports.md
+++ b/doc/ports.md
@@ -40,7 +40,7 @@ https://github.com/hardpixel/mrml-ruby
 
 React components for MJML components.
 
-https://github.com/wix-incubator/mjml-react
+https://github.com/faire/mjml-react#readme
 
 ## Python / Django: django-mjml
 


### PR DESCRIPTION
Faire has taken over maintenance of mjml-react and has it in a stable state

v2 = perfect replica of https://github.com/wix-incubator/mjml-react
v3 = minor improvements on v2 that help with maintainability and types (LTS)
v4.beta = new features

cc: @daliusd (from https://github.com/wix-incubator/mjml-react)