### PR TITLE
Fix % mobile width in mjml-column

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -138,7 +138,7 @@ export default class MjColumn extends BodyComponent {
         return width
       case 'px':
       default:
-        return `${parsedWidth / parseInt(containerWidth, 10)}%`
+        return `${parsedWidth / parseInt(containerWidth, 10) * 100}%`
     }
   }
 


### PR DESCRIPTION
`getMobileWidth` in `mjml-column` should return normal percents instead of 0.xy%