### PR TITLE
fix(mjml-hero): fixed-height hero no longer overlaps subsequent content in Outlook 365 120 DPI)

### DIFF
--- a/packages/mjml-hero/src/index.js
+++ b/packages/mjml-hero/src/index.js
@@ -99,18 +99,6 @@ export default class MjHero extends BodyComponent {
         'padding-bottom': `${backgroundRatio}%`,
         'mso-padding-bottom-alt': '0',
       },
-      hero: {
-        background: this.getBackground(),
-        'background-position': this.getAttribute('background-position'),
-        'background-repeat': 'no-repeat',
-        'border-radius': this.getAttribute('border-radius'),
-        padding: this.getAttribute('padding'),
-        'padding-top': this.getAttribute('padding-top'),
-        'padding-left': this.getAttribute('padding-left'),
-        'padding-right': this.getAttribute('padding-right'),
-        'padding-bottom': this.getAttribute('padding-bottom'),
-        'vertical-align': this.getAttribute('vertical-align'),
-      },
       'outlook-table': {
         width: containerWidth,
       },
@@ -270,7 +258,18 @@ export default class MjHero extends BodyComponent {
   renderMode() {
     const commonAttributes = {
       background: this.getAttribute('background-url'),
-      style: 'hero',
+      style: {
+        background: this.getBackground(),
+        'background-position': this.getAttribute('background-position'),
+        'background-repeat': 'no-repeat',
+        'border-radius': this.getAttribute('border-radius'),
+        padding: this.getAttribute('padding'),
+        'padding-top': this.getAttribute('padding-top'),
+        'padding-left': this.getAttribute('padding-left'),
+        'padding-right': this.getAttribute('padding-right'),
+        'padding-bottom': this.getAttribute('padding-bottom'),
+        'vertical-align': this.getAttribute('vertical-align'),
+      },
     }
 
     /* eslint-disable no-alert, no-case-declarations */
@@ -297,6 +296,10 @@ export default class MjHero extends BodyComponent {
             ${this.htmlAttributes({
               ...commonAttributes,
               height,
+              style: {
+                ...commonAttributes.style,
+                height: `${height}px`,
+              },
             })}
           >
             ${this.renderContent()}


### PR DESCRIPTION
Fixes #2657

## Reproduction

Generate an email from the following MJML, send it using putsmail.com, and then open it in Outlook 365 on Windows 10 at 120 DPI. 

```mjml
<mjml>
  <mj-body>
    <mj-hero height="256px" mode="fixed-height" background-color="#000000" background-url="https://picsum.photos/1200/512" background-width="600px" background-height="256px" vertical-align="middle">
      <mj-text color="#ffffff">
        <h2>Call to action!</h2>
        <p>Try clicking the button below.</p>
      </mj-text>
      <mj-button color="#000000" background-color="#ffffff" align="left">Example Button</mj-button>
    </mj-hero>
    <mj-section>
      <mj-column>
        <mj-text align="center">
          <p><a href="https://www.example.com" rel="noopener">Footer</a></p>
        </mj-text>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

**Before Fix**
The hero image overlaps the footer link.

<img width="784" alt="Screenshot 2023-03-24 at 11 35 11 AM" src="https://user-images.githubusercontent.com/92558494/227589622-b5ece63a-72b7-444e-b7be-8db104508f67.png">


**After Fix**
The footer link is correctly spaced below the hero image.

<img width="780" alt="Screenshot 2023-03-24 at 11 36 37 AM" src="https://user-images.githubusercontent.com/92558494/227589552-14d01b68-b366-45a9-b0da-4a0566cd70e8.png">

Thank you!