### PR TITLE
fix(mj-carousel): correct media query

### DIFF
--- a/packages/mjml-carousel/src/Carousel.js
+++ b/packages/mjml-carousel/src/Carousel.js
@@ -178,7 +178,7 @@ export default class MjCarousel extends BodyComponent {
 
       [owa] .mj-carousel-thumbnail { display: none !important; }
       
-      @media screen yahoo {
+      @media screen, yahoo {
           .mj-carousel-${this.carouselId}-icons-cell,
           .mj-carousel-previous-icons,
           .mj-carousel-next-icons {


### PR DESCRIPTION
That media query should have a comma between screen and yahoo to be valid