### PR TITLE
fix(mjml-core): close negative condition

### DIFF
--- a/packages/mjml-core/src/helpers/conditionalTag.js
+++ b/packages/mjml-core/src/helpers/conditionalTag.js
@@ -2,7 +2,7 @@ export const startConditionalTag = '<!--[if mso | IE]>'
 export const startMsoConditionalTag = '<!--[if mso]>'
 export const endConditionalTag = '<![endif]-->'
 export const startNegationConditionalTag = '<!--[if !mso | IE]><!-->'
-export const startMsoNegationConditionalTag = '<!--[if !mso><!-->'
+export const startMsoNegationConditionalTag = '<!--[if !mso]><!-->'
 export const endNegationConditionalTag = '<!--<![endif]-->'
 
 export default function conditionalTag(content, negation = false) {


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Conditional_comment we need that square bracket to close that conditional tag