### PR TITLE
fix(mjml-core): proper validation of mjml tag

### DIFF
--- a/packages/mjml-document/package.json
+++ b/packages/mjml-document/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "mjml-document",
+    "description": "mjml-document",
+    "version": "4.14.1",
+    "main": "lib/index.js",
+    "files": [
+      "lib"
+    ],
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/mjmlio/mjml.git",
+      "directory": "packages/mjml-document"
+    },
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/mjmlio/mjml/issues"
+    },
+    "homepage": "https://mjml.io",
+    "scripts": {
+      "clean": "rimraf lib",
+      "build": "babel src --out-dir lib --root-mode upward"
+    },
+    "dependencies": {
+      "@babel/runtime": "^7.14.6",
+      "lodash": "^4.17.21",
+      "mjml-core": "4.14.1"
+    },
+    "devDependencies": {
+      "@babel/cli": "^7.8.4",
+      "rimraf": "^3.0.2"
+    }
+  }
+  

--- a/packages/mjml-document/src/index.js
+++ b/packages/mjml-document/src/index.js
@@ -1,0 +1,11 @@
+import { BodyComponent } from 'mjml-core'
+
+export default class MjDocument extends BodyComponent {
+  static componentName = 'mjml'
+
+  static endingTag = false
+
+  render() {
+    return ''
+  }
+}

--- a/packages/mjml-preset-core/src/index.js
+++ b/packages/mjml-preset-core/src/index.js
@@ -7,6 +7,7 @@ import {
   AccordionText,
   AccordionTitle,
 } from 'mjml-accordion'
+import Document from 'mjml-document'
 import Body from 'mjml-body'
 import Head from 'mjml-head'
 import HeadAttributes from 'mjml-head-attributes'
@@ -31,6 +32,7 @@ import Wrapper from 'mjml-wrapper'
 import dependencies from './dependencies'
 
 const components = [
+  Document,
   Body,
   Head,
   HeadAttributes,

--- a/packages/mjml-validator/src/index.js
+++ b/packages/mjml-validator/src/index.js
@@ -5,8 +5,6 @@ import dependencies, {
   assignDependencies,
 } from './dependencies'
 
-const SKIP_ELEMENTS = ['mjml']
-
 export const formatValidationError = ruleError
 
 export { rulesCollection, registerRule }
@@ -17,7 +15,7 @@ export default function MJMLValidator(element, options = {}) {
   const { children, tagName } = element
   const errors = []
 
-  const skipElements = options.skipElements || SKIP_ELEMENTS
+  const skipElements = options.skipElements || []
 
   if (options.dependencies == null) {
     console.warn('"dependencies" option should be provided to mjml validator')


### PR DESCRIPTION
Fixes https://github.com/mjmlio/mjml/issues/2695
So, the dependency rules were not working correctly because `<mjml>` tag was entirely ignored. Without it MJML wasn't working, so I made new component that represents the `<mjml>` tag , so dependency rules can work properly. It can encapsulate document, for example it can be used to generate skeleton code here in render instead of special behavior for that, but it needs more refactoring then.
Couldn't find place in package to write tests so here is proof of validity:
https://github.com/mjmlio/mjml/assets/32848266/39905889-2f15-4500-b405-4edd02e91110

