### PR TITLE
fix: remove invalid vertical-align property from column

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -258,7 +258,6 @@ export default class MjColumn extends BodyComponent {
                 <td
                   ${component.htmlAttributes({
                     align: component.getAttribute('align'),
-                    'vertical-align': component.getAttribute('vertical-align'),
                     class: component.getAttribute('css-class'),
                     style: {
                       background: component.getAttribute(


### PR DESCRIPTION
Fixes #2684

Tested and confirmed that the property is unnecessary and is not outputted by MJML.