### PR TITLE
fix: allow getShorthandAttrValue to parse borders

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -40,8 +40,8 @@ export default class MjColumn extends BodyComponent {
     const { nonRawSiblings } = this.props
     const { borders, paddings } = this.getBoxWidths()
     const innerBorders =
-      this.getShorthandAttrValue('inner-border', 'left') +
-      this.getShorthandAttrValue('inner-border', 'right')
+      this.getShorthandBorderValue('left', 'inner-border') +
+      this.getShorthandBorderValue('right', 'inner-border')
 
     const allPaddings = paddings + borders + innerBorders
 

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -117,6 +117,10 @@ export class BodyComponent extends Component {
     const mjAttributeDirection = this.getAttribute(`${attribute}-${direction}`)
     const mjAttribute = this.getAttribute(attribute)
 
+    if (attribute === 'border' || attribute === 'inner-border') {
+      return borderParser(mjAttributeDirection || mjAttribute || '0')
+    }
+
     if (mjAttributeDirection) {
       return parseInt(mjAttributeDirection, 10)
     }

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -117,10 +117,6 @@ export class BodyComponent extends Component {
     const mjAttributeDirection = this.getAttribute(`${attribute}-${direction}`)
     const mjAttribute = this.getAttribute(attribute)
 
-    if (attribute === 'border' || attribute === 'inner-border') {
-      return borderParser(mjAttributeDirection || mjAttribute || '0')
-    }
-
     if (mjAttributeDirection) {
       return parseInt(mjAttributeDirection, 10)
     }
@@ -132,10 +128,10 @@ export class BodyComponent extends Component {
     return shorthandParser(mjAttribute, direction)
   }
 
-  getShorthandBorderValue(direction) {
+  getShorthandBorderValue(direction, attribute = 'border') {
     const borderDirection =
-      direction && this.getAttribute(`border-${direction}`)
-    const border = this.getAttribute('border')
+      direction && this.getAttribute(`${attribute}-${direction}`)
+    const border = this.getAttribute(attribute)
 
     return borderParser(borderDirection || border || '0')
   }


### PR DESCRIPTION
Fixes #2688

This fixes the column component rendering `style="width:NaNInfinity;"` by improving `getShorthandAttrValue` to use the `borderParser` for border and inner-border properties.