### PR TITLE
Export jsonToXML helper to be used by components

### DIFF
--- a/packages/mjml-core/src/helpers/jsonToXML.js
+++ b/packages/mjml-core/src/helpers/jsonToXML.js
@@ -4,7 +4,7 @@ const jsonToXML = ({ tagName, attributes, children, content }) => {
       ? children.map(jsonToXML).join('\n')
       : content || ''
 
-  const stringAttrs = Object.keys(attributes)
+  const stringAttrs = Object.keys(attributes || {})
     .map((attr) => `${attr}="${attributes[attr]}"`)
     .join(' ')
 

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -35,6 +35,7 @@ import mergeOutlookConditionnals from './helpers/mergeOutlookConditionnals'
 import minifyOutlookConditionnals from './helpers/minifyOutlookConditionnals'
 import defaultSkeleton from './helpers/skeleton'
 import { initializeType } from './types/type'
+import jsonToXML from './helpers/jsonToXML'
 
 import handleMjmlConfig, {
   readMjmlConfig,
@@ -443,6 +444,7 @@ export {
   suffixCssClasses,
   handleMjmlConfig,
   initializeType,
+  jsonToXML,
 }
 
 export { BodyComponent, HeadComponent } from './createComponent'

--- a/packages/mjml-core/tests/jsonToXml-test.js
+++ b/packages/mjml-core/tests/jsonToXml-test.js
@@ -30,7 +30,7 @@ const json = {
                          color: '#F45E43',
                          'font-family': 'helvetica' },
                       content: 'Hello World' } ],
-                 attributes: {} } ],
+                  } ],
             attributes: {} } ],
        attributes: {} } ],
   attributes: {} }


### PR DESCRIPTION
### Exporting `jsonToXML`
Component `render()` function must return a valid XML string.  
To achieve that, programmers can manipulate xml strings, it's humain readable but harder to test.  

To mitigate that, component creators should be able to use mjml json notation and then call the `jsonToXML` just before returning the component within the `render()` static method.  
In that way component methods that generate markups are more programmable and testable.  
It also ensure that rendered XML is valid comparated to a manually generated string where hard to spot errors can occur.  

### Making `attributes` key optional
I also improved a bit the `jsonToXML` helper by allowing the `attributes` field to be missing.  
It allows the generated JSON to be a lot shorter.
I randomly removed an `attributes` key from the test json to ensure that the parsing works either way.