### PR TITLE
Automatic component dependencies registration

### DIFF
--- a/packages/mjml-core/src/components.js
+++ b/packages/mjml-core/src/components.js
@@ -1,4 +1,5 @@
 import { kebabCase } from 'lodash'
+import { registerDependencies } from "mjml-validator";
 
 const components = {}
 
@@ -8,8 +9,12 @@ export function assignComponents(target, source) {
   }
 }
 
-export function registerComponent(Component) {
+export function registerComponent(Component, options = {}) {
   assignComponents(components, [Component])
+
+  if (Component.dependencies && options.registerDependencies) {
+    registerDependencies(Component.dependencies)
+  }
 }
 
 export default components

--- a/packages/mjml-core/src/components.js
+++ b/packages/mjml-core/src/components.js
@@ -1,5 +1,5 @@
 import { kebabCase } from 'lodash'
-import { registerDependencies } from "mjml-validator";
+import { registerDependencies } from 'mjml-validator'
 
 const components = {}
 


### PR DESCRIPTION
### Automatic component dependencies registration
To avoid recurrent questionning when using `registerComponent` function, I added a second parameter to the function allowing the user to pass `options`.  

If the option `registerDependencies` is _truthy_, and the current component has a `dependencies` property, the component dependencies will be automatically registered.

closes #2784