### PR TITLE
fix mjml-navbar documentation

### DIFF
--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -32,7 +32,7 @@ Displays a menu for navigation with an optional hamburger mode for mobile device
 
 ### mj-navbar
 
-Individual links of the menu should we wrapped inside mj-navbar.
+Individual links of the menu should be wrapped inside mj-navbar.
 
 
 Standard Desktop:


### PR DESCRIPTION
corrected a trivial mistake with spelling.