### PR TITLE
fix: border-radius is not work when i have already set border-collaps…

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -93,6 +93,7 @@ export default class MjSection extends BodyComponent {
         'padding-right': this.getAttribute('padding-right'),
         'padding-top': this.getAttribute('padding-top'),
         'text-align': this.getAttribute('text-align'),
+        'border-radius': this.getAttribute('border-radius'),
       },
       div: {
         ...(fullWidth ? {} : background),


### PR DESCRIPTION
Hello,

I have already seen this issue: https://github.com/mjmlio/mjml/issues/2741 and this ex: https://mjml.io/try-it-live/8tUiBjdfYV

But it doesn't meet my needs. In the current demo, I find myself needing to add various class names to address the border-radius for multiple Section components. What I aim for is to have the td's border-radius follow the values set on the component, eliminating the necessity for numerous class names.

I am planning to utilize [mjml](https://github.com/mjmlio/mjml) to develop a visual email style editor, allowing users to choose whether to enable border-collapse: separate !important;. I'll inform users of the associated risks while ensuring that border-radius works seamlessly on the Section component. I believe it makes logical sense to apply the border-radius solely to td, without introducing compatibility issues. If there are considerations I may have overlooked, please reject this PR. Thank you for your attention.

* Before: ` border-radius`  is not work
![image](https://github.com/mjmlio/mjml/assets/67814702/f6225e28-80bf-43da-be74-dacfb8019d8d)

* After : Everything looks fine
![image](https://github.com/mjmlio/mjml/assets/67814702/436978f0-1799-4916-a57c-efef76ecb82c)
