### PR TITLE
Bump lodash from 4.17.15 to 4.17.21

### DIFF
--- a/packages/mjml-parser-xml/package.json
+++ b/packages/mjml-parser-xml/package.json
@@ -25,7 +25,7 @@
     "@babel/runtime": "^7.23.9",
     "detect-node": "2.1.0",
     "htmlparser2": "^9.1.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8203

dependabot is raising security issues because of that