### PR TITLE
[FIX] Remove extraneous quotes around background-url

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -112,7 +112,7 @@ export default class MjSection extends BodyComponent {
       this.getAttribute('background-color'),
       ...(this.hasBackground()
         ? [
-            `url('${this.getAttribute('background-url')}')`,
+            `url(${this.getAttribute('background-url')})`,
             this.getBackgroundString(),
             `/ ${this.getAttribute('background-size')}`,
             this.getAttribute('background-repeat'),


### PR DESCRIPTION
Following my report on #2833 I'd like to suggest the following changes, but I believe some discussion should happen first.

As per [the CSS spec](https://developer.mozilla.org/en-US/docs/Web/CSS/url), `url()` accepts optional quotes in some cases where the URL string contains special characters. Therefore, it is reasonable for MJML to assume that we should wrap a user-provided URL in quotes, just to be on the safe side. After all, the docs says it's optional so it should work, right?

Well, Google & more specifically Gmail decided otherwise. Whether the `url()` contains a quoted value, such as `url('https://example.com/image.png')`, it will somehow affect the design.

Here's a simplified repo snippet:

```mjml
<mj-section
  background-url="{{package.cover}}"
  background-size="cover"
  background-position="center center"
  background-repeat="no-repeat"
  background-color="#d0d0d3"
>
  <mj-group>
    <mj-column width="20%">
      <mj-image
        align="left"
        src="{{package.logo}}"
      />
    </mj-column>
    <mj-column width="80%">
      <mj-image
        src="{{package.countryFlagUri}}"
        align="right"
      />
    </mj-column>
  </mj-group>
</mj-section>
```

And here's what it looks like rendered in actual email clients:

| Description | Screenshot |
| --- | --- |
| Apple Mail, with or without this fix | ![Screenshot 2024-02-26 at 19 04 50](https://github.com/mjmlio/mjml/assets/4186230/4ff796bc-4936-4e1d-bfaa-fc6408e8730a) |
| Gmail, without fix. *Notice it's the same image appearing twice, though with a different crop.* | ![Screenshot 2024-02-26 at 19 04 35](https://github.com/mjmlio/mjml/assets/4186230/2b12557e-4d1a-42e4-8b18-34785ca0dd97) |
| Gmail, with fix | ![Screenshot 2024-02-26 at 19 04 12](https://github.com/mjmlio/mjml/assets/4186230/ab6e7d32-7402-4961-9e4b-b8972b543ce7) |

So in the end I'm not 100% sure removing the quotes here is a foolproof solution, but in my case the changes from this PR allowed me to generate emails that work better on Gmail.

Important thing to know: [the MJML.io live editor](https://mjml.io/try-it-live) somehow does not add the quotes! I even installed the exact same version as the live editor (version 4.9.3 at time of writing), and locally the quotes always appeared. So I'm not sure, maybe there's some config/outdated dependency happening here? The live editor is what allowed me to diagnose the problem in the first place by diffing with my local outputs.

Lastly, if you think this change is acceptable, we might want to spread it to the `<mj-hero/>` component as well, as it seems to be using the same background-url quotes.

Any comments welcome!

Fixes #2833