### PR TITLE
fix: When I set the px unit.  I got unexpected results in mobile view

### DIFF
--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -137,8 +137,9 @@ export default class MjColumn extends BodyComponent {
       case '%':
         return width
       case 'px':
+        return width
       default:
-        return `${parsedWidth / parseInt(containerWidth, 10) * 100}%`
+        return `${(parsedWidth / parseInt(containerWidth, 10)) * 100}%`
     }
   }
 
@@ -267,9 +268,8 @@ export default class MjColumn extends BodyComponent {
                       padding: component.getAttribute('padding'),
                       'padding-top': component.getAttribute('padding-top'),
                       'padding-right': component.getAttribute('padding-right'),
-                      'padding-bottom': component.getAttribute(
-                        'padding-bottom',
-                      ),
+                      'padding-bottom':
+                        component.getAttribute('padding-bottom'),
                       'padding-left': component.getAttribute('padding-left'),
                       'word-break': 'break-word',
                     },


### PR DESCRIPTION
When I use a px value, it shouldn't automatically convert it to a percentage for me, so I get unexpected results in the phone view.


* web view
everything is ok 
![image](https://github.com/mjmlio/mjml/assets/67814702/825bc75d-2399-412c-bad5-104cebaf5f32)

* mobile
unexpected results 
![image](https://github.com/mjmlio/mjml/assets/67814702/b074020d-7492-465a-bc0b-12b7315daaef)
![image](https://github.com/mjmlio/mjml/assets/67814702/5b80d82b-116a-4077-84ba-fe25bbd09561)


--Thank you for your review
