### PR TITLE
doc: Remove blank "Nesting" section

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -80,17 +80,3 @@ Let's take the following layout to illustrate this:
   </mj-body>
 </mjml>
 ```
-
-## Nesting
-
-```html
-<mjml>
-  <mj-body>
-    <mj-section>
-      <mj-column>
-        <!-- Column content -->
-      </mj-column>
-    </mj-section>
-  </mj-body>
-</mjml>
-```


### PR DESCRIPTION
The "Nesting" section of https://documentation.mjml.io/#nesting is blank.

It looks like it was accidentally blanked out in https://github.com/mjmlio/mjml/commit/a27f9364e5c43a796f9eea49fb00763ccad903bb#diff-eba2e6e0c715e18058f56e6aefc9eb211d905dd523e4814f14fe4932ed1d7b4eL97

I don't think the remaining code snippet is meaningful here, and so this PR removes the empty section, but if the old "Nesting" section or the "Tag Styling" section should be restored, I'd be happy to do that, instead.