### PR TITLE
feat: adds direction property to mj-social-element to reverse icon/text order

### DIFF
--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -102,6 +102,7 @@ padding-left                | px          | left offset                      | n
 padding-right               | px          | right offset                       | n/a
 padding-top                 | px          | top offset                         | n/a
 icon-padding                | px          | padding around the icon       | 0px
+icon-position               | string      | left/right                    | right
 text-padding                | px          | padding around the text       | 4px 4px 4px 0
 sizes                       | media query & width | set icon width based on query | n/a
 src                         | url         | image source                  | Each social `name` has its own default

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -99,7 +99,7 @@ export default class MjSocialElement extends BodyComponent {
 
   static allowedAttributes = {
     align: 'enum(left,center,right)',
-    direction: 'enum(left,right)',
+    'icon-position': 'enum(left,right)',
     'background-color': 'color',
     color: 'color',
     'border-radius': 'unit(px)',
@@ -133,7 +133,7 @@ export default class MjSocialElement extends BodyComponent {
   static defaultAttributes = {
     alt: '',
     align: 'left',
-    direction: 'left',
+    'icon-position': 'left',
     color: '#000',
     'border-radius': '3px',
     'font-family': 'Ubuntu, Helvetica, Arial, sans-serif',
@@ -234,7 +234,7 @@ export default class MjSocialElement extends BodyComponent {
     } = this.getSocialAttributes()
 
     const hasLink = !!this.getAttribute('href')
-    const direction = this.getAttribute('direction')
+    const iconPosition = this.getAttribute('icon-position')
 
     const makeIcon = () => `
         <td ${this.htmlAttributes({ style: 'td' })}>
@@ -315,7 +315,7 @@ export default class MjSocialElement extends BodyComponent {
           class: this.getAttribute('css-class'),
         })}
       >
-        ${direction === 'left' ? renderLeft() : renderRight() }
+        ${iconPosition === 'left' ? renderLeft() : renderRight() }
       </tr>
     `
   }

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -99,6 +99,7 @@ export default class MjSocialElement extends BodyComponent {
 
   static allowedAttributes = {
     align: 'enum(left,center,right)',
+    direction: 'enum(left,right)',
     'background-color': 'color',
     color: 'color',
     'border-radius': 'unit(px)',
@@ -132,6 +133,7 @@ export default class MjSocialElement extends BodyComponent {
   static defaultAttributes = {
     alt: '',
     align: 'left',
+    direction: 'left',
     color: '#000',
     'border-radius': '3px',
     'font-family': 'Ubuntu, Helvetica, Arial, sans-serif',
@@ -232,13 +234,10 @@ export default class MjSocialElement extends BodyComponent {
     } = this.getSocialAttributes()
 
     const hasLink = !!this.getAttribute('href')
+    const direction = this.getAttribute('direction')
 
-    return `
-      <tr
-        ${this.htmlAttributes({
-          class: this.getAttribute('css-class'),
-        })}
-      >
+    const makeIcon = () => {
+      return `
         <td ${this.htmlAttributes({ style: 'td' })}>
           <table
             ${this.htmlAttributes({
@@ -279,6 +278,10 @@ export default class MjSocialElement extends BodyComponent {
             </tbody>
           </table>
         </td>
+      `
+    }
+
+    const makeContent = () => `
         ${
           this.getContent()
             ? `
@@ -303,6 +306,18 @@ export default class MjSocialElement extends BodyComponent {
           `
             : ''
         }
+      `
+
+    const renderLeft = () => `${makeIcon()} ${makeContent()}`
+    const renderRight = () => `${makeContent()} ${makeIcon()}`
+
+    return `
+      <tr
+        ${this.htmlAttributes({
+          class: this.getAttribute('css-class'),
+        })}
+      >
+        ${direction === 'left' ? renderLeft() : renderRight() }
       </tr>
     `
   }

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -236,8 +236,7 @@ export default class MjSocialElement extends BodyComponent {
     const hasLink = !!this.getAttribute('href')
     const direction = this.getAttribute('direction')
 
-    const makeIcon = () => {
-      return `
+    const makeIcon = () => `
         <td ${this.htmlAttributes({ style: 'td' })}>
           <table
             ${this.htmlAttributes({
@@ -279,7 +278,6 @@ export default class MjSocialElement extends BodyComponent {
           </table>
         </td>
       `
-    }
 
     const makeContent = () => `
         ${


### PR DESCRIPTION
![image](https://github.com/mjmlio/mjml/assets/201422/3d403921-37b5-42aa-9feb-7f3c4f8d3fd3)

I've been running into a lot of situations in email builds, especially on links, where designers place an arrow or other image on the right side of the text. mj-social does a fantastic job with image/text layouts, but it was lacking an option to reverse the order of the image and the text. I've added a new property `direction` as an enum of 'left' or 'right' which swaps the rendering of the TDs in the render method to support this change.