### PR TITLE
Pass parent attributes to rawXML child components

### DIFF
--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -207,7 +207,10 @@ export class BodyComponent extends Component {
     children = children || this.props.children
 
     if (rawXML) {
-      return children.map((child) => jsonToXML(child)).join('\n')
+      return children.map((child) => {
+        child.attributes = {...attributes, ...child.attributes}
+        jsonToXML(child)
+      }).join('\n')
     }
 
     const sibling = children.length

--- a/packages/mjml-core/src/createComponent.js
+++ b/packages/mjml-core/src/createComponent.js
@@ -209,7 +209,7 @@ export class BodyComponent extends Component {
     if (rawXML) {
       return children.map((child) => {
         child.attributes = {...attributes, ...child.attributes}
-        jsonToXML(child)
+        return jsonToXML(child)
       }).join('\n')
     }
 


### PR DESCRIPTION
Currently you are unable to pass attributes from a parent component to it's children components if the child is rawXML. This fix enables the parent to pass attributes to the rawXML children.