### PR TITLE
[Accessibility] - add role main landmark

### DIFF
--- a/packages/mjml-body/src/index.js
+++ b/packages/mjml-body/src/index.js
@@ -39,6 +39,7 @@ export default class MjBody extends BodyComponent {
         ${this.htmlAttributes({
           class: this.getAttribute('css-class'),
           style: 'div',
+          role: 'main',
           lang,
           dir,
         })}


### PR DESCRIPTION
### TLDLR; Add role main to MjBody 

For accessibility the main landmark is important to point the user to the main content of the email and navigate easily with a screen reader. We can use the `<main>` tag or add a `role="main"` to a `<div>`

We don't use `<main>` tag here because of some limitations from email providers (Outlook, Gmail, etc.).

So update the MjBody class to add `role: 'main'` as parameter in `htmlAttributes` function. 

More on main [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/main_role)