### PR TITLE
fix(mjml-table): supports 'auto' table width - #2906

### DIFF
--- a/packages/mjml-table/README.md
+++ b/packages/mjml-table/README.md
@@ -60,4 +60,4 @@ padding-right               | percent/px                  | right offset        
 padding-top                 | percent/px                  | top offset                     | n/a
 role                        | none/presentation           | specify the role attribute     | n/a
 table-layout                | auto/fixed/initial/inherit  | sets the table layout.         | auto
-width                       | percent/px                  | table width                    | 100%
+width                       | percent/px/auto             | table width                    | 100%

--- a/packages/mjml-table/src/index.js
+++ b/packages/mjml-table/src/index.js
@@ -27,7 +27,7 @@ export default class MjTable extends BodyComponent {
     role: 'enum(none,presentation)',
     'table-layout': 'enum(auto,fixed,initial,inherit)',
     'vertical-align': 'enum(top,bottom,middle)',
-    width: 'unit(px,%)',
+    width: 'unit(px,%,auto)',
   }
 
   static defaultAttributes = {
@@ -60,8 +60,12 @@ export default class MjTable extends BodyComponent {
 
   getWidth() {
     const width = this.getAttribute('width')
-    const { parsedWidth, unit } = widthParser(width)
 
+    if (width === 'auto') {
+      return width
+    }
+
+    const { parsedWidth, unit } = widthParser(width)
     return unit === '%' ? width : parsedWidth
   }
 

--- a/packages/mjml/test/index.js
+++ b/packages/mjml/test/index.js
@@ -1,2 +1,3 @@
 require('./html-attributes.test')
 require('./lazy-head-style.test')
+require('./tableWidth.test')

--- a/packages/mjml/test/tableWidth.test.js
+++ b/packages/mjml/test/tableWidth.test.js
@@ -1,0 +1,98 @@
+const chai = require('chai')
+const { load } = require('cheerio')
+const mjml = require('../lib')
+
+const input = `
+<mjml>
+    <mj-body>
+        <mj-wrapper>
+            <mj-section>
+                <mj-column>
+                    <mj-table css-class="table">
+                        <tr>
+                            <th style="border: 1px solid black;text-align: left;">
+                                Default Width
+                            </th>
+                            <td style="border: 1px solid black;">
+                                100%
+                            </td>
+                        </tr>
+                    </mj-table>
+                </mj-column>
+            </mj-section>
+            <mj-section>
+                <mj-column>
+                    <mj-table width="500px" css-class="table">
+                        <tr>
+                            <th style="border: 1px solid black;text-align: left;">
+                                Pixel Width
+                            </th>
+                            <td style="border: 1px solid black;">
+                                500px
+                            </td>
+                        </tr>
+                    </mj-table>
+                </mj-column>
+            </mj-section>
+            <mj-section>
+                <mj-column>
+                    <mj-table width="80%" css-class="table">
+                        <tr>
+                            <th style="border: 1px solid black;text-align: left;">
+                                Percentage Width
+                            </th>
+                            <td style="border: 1px solid black;">
+                                80%
+                            </td>
+                        </tr>
+                    </mj-table>
+                </mj-column>
+            </mj-section>
+            <mj-section css-class="section">
+                <mj-column>
+                    <mj-table width="auto" css-class="table">
+                        <tr>
+                            <th style="border: 1px solid black;text-align: left;">
+                                Auto Width
+                            </th>
+                            <td style="border: 1px solid black;">
+                                Auto
+                            </td>
+                        </tr>
+                    </mj-table>
+                </mj-column>
+            </mj-section>
+        </mj-wrapper>
+    </mj-body>
+</mjml>
+`
+
+const { html } = mjml(input)
+
+const $ = load(html)
+
+// width values should be correct
+chai
+  .expect(
+    $('.table table')
+      .map(function getAttr() {
+        return $(this).attr('width')
+      })
+      .get(),
+    'Width values on tables',
+  )
+  .to.eql(['100%', '500', '80%', 'auto'])
+
+// style values should be correct
+chai
+  .expect(
+    $('.table table')
+      .map(function getAttr() {
+        const start = $(this).attr('style').indexOf('width:') + 6
+        const end = $(this).attr('style').indexOf(';', start)
+        return $(this).attr('style').substring(start, end)
+      })
+      .get(),
+    'Width in CSS style values on tables',
+  )
+  .to.eql(['100%', '500px', '80%', 'auto'])


### PR DESCRIPTION
Added the ability to set 'auto' as the value of the width attribute on a mj-table, which will size the table to the width of the content.

Also added an automated test to check default/permissible width values on a table (default, px, %, auto)