### PR TITLE
fix(mjml-wrapper/mjml-section): border-radius not being applied #2961

### DIFF
--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -55,6 +55,8 @@ export default class MjSection extends BodyComponent {
 
     const fullWidth = this.isFullWidth()
 
+    const hasBorderRadius = this.hasBorderRadius()
+
     const background = this.getAttribute('background-url')
       ? {
           background: this.getBackground(),
@@ -72,12 +74,11 @@ export default class MjSection extends BodyComponent {
       tableFullwidth: {
         ...(fullWidth ? background : {}),
         width: '100%',
-        'border-radius': this.getAttribute('border-radius'),
       },
       table: {
         ...(fullWidth ? {} : background),
         width: '100%',
-        'border-radius': this.getAttribute('border-radius'),
+        ...(hasBorderRadius && { 'border-collapse': 'separate' }),
       },
       td: {
         border: this.getAttribute('border'),
@@ -85,6 +86,7 @@ export default class MjSection extends BodyComponent {
         'border-left': this.getAttribute('border-left'),
         'border-right': this.getAttribute('border-right'),
         'border-top': this.getAttribute('border-top'),
+        'border-radius': this.getAttribute('border-radius'),
         direction: this.getAttribute('direction'),
         'font-size': '0px',
         padding: this.getAttribute('padding'),
@@ -97,7 +99,6 @@ export default class MjSection extends BodyComponent {
       div: {
         ...(fullWidth ? {} : background),
         margin: '0px auto',
-        'border-radius': this.getAttribute('border-radius'),
         'max-width': containerWidth,
       },
       innerDiv: {
@@ -185,6 +186,11 @@ export default class MjSection extends BodyComponent {
 
   isFullWidth() {
     return this.getAttribute('full-width') === 'full-width'
+  }
+
+  hasBorderRadius() {
+    const borderRadius = this.getAttribute('border-radius')
+    return borderRadius !== '' && typeof borderRadius !== 'undefined'
   }
 
   renderBefore() {

--- a/packages/mjml/test/index.js
+++ b/packages/mjml/test/index.js
@@ -1,3 +1,4 @@
 require('./html-attributes.test')
 require('./lazy-head-style.test')
 require('./tableWidth.test')
+require('./wrapper-border-radius.test')

--- a/packages/mjml/test/wrapper-border-radius.test.js
+++ b/packages/mjml/test/wrapper-border-radius.test.js
@@ -1,0 +1,49 @@
+const chai = require('chai')
+const { load } = require('cheerio')
+const mjml = require('../lib')
+
+const input = `
+<mjml>
+  <mj-body>
+    <mj-wrapper border="1px solid red" border-radius="10px">
+      <mj-section>
+        <mj-column>
+          <mj-text font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>
+`
+
+const { html } = mjml(input)
+
+const $ = load(html)
+
+// border radius values should be correct
+chai
+  .expect(
+    $('body > div > div > table:first-child > tbody > tr > td')
+      .map(function getAttr() {
+        const start = $(this).attr('style').indexOf('border-radius:') + 14
+        const end = $(this).attr('style').indexOf(';', start)
+        return $(this).attr('style').substring(start, end)
+      })
+      .get(),
+    'Border-radius in CSS style values on mj-wrapper',
+  )
+  .to.eql(['10px'])
+
+// border collapse values should be correct
+chai
+  .expect(
+    $('body > div > div > table:first-child')
+      .map(function getAttr() {
+        const start = $(this).attr('style').indexOf('border-collapse:') + 16
+        const end = $(this).attr('style').indexOf(';', start)
+        return $(this).attr('style').substring(start, end)
+      })
+      .get(),
+    'Border-collapse in CSS style values on mj-wrapper',
+  )
+  .to.eql(['separate'])


### PR DESCRIPTION
mj-wrapper and mj-section were not respecting the border-radius declaration.

Fixes the issue and added an automated test. 

fixes #2961 