### PR TITLE
feature(mjml docs): Added link to support matrix MJML-8

### DIFF
--- a/doc/components_1.md
+++ b/doc/components_1.md
@@ -26,6 +26,11 @@ For instance, the `mj-button` component is, on the inside, a complex HTML layout
 </table>
 ```
 
+## Which email clients/versions are supported?
+
+For full details of component support, [please visit our support matrix](https://mjml.io/compatibility).
+
+
 ## mjml
 
 A MJML document starts with a `<mjml>` tag, it can contain only `mj-head` and `mj-body` tags. Both have the same purpose of `head` and `body` in a HTML document.


### PR DESCRIPTION
**What:** 
Added a section in the MJML documentation under 'Components' to link to the support matrix on the website.

**Why:** 
Currently the only access is via the FAQ page on the website and users may not know it's there.

**How:** 
Updated MD file