### PR TITLE
bugfix(mjml-wrapper): allowed attributes not inheriting #3011

### DIFF
--- a/packages/mjml-wrapper/src/index.js
+++ b/packages/mjml-wrapper/src/index.js
@@ -5,6 +5,7 @@ export default class MjWrapper extends MjSection {
   static componentName = 'mj-wrapper'
 
   static allowedAttributes = {
+    ...MjSection.allowedAttributes,
     gap: 'unit(px)',
   }
 


### PR DESCRIPTION
**What:**
common attributes (padding, border, background-color etc) are now illegal on mj-wrapper

**Why:**
Adding 'static allowedAttributes' for 'gap' caused other attributes to become illegal due to no inheritance. Caused by previous feature update: https://github.com/mjmlio/mjml/pull/3004

**How:**
Added inheritance for all attributes

fixes #3011 