### PR TITLE
Update mjml-browser globalObject

### DIFF
--- a/packages/mjml-browser/webpack.config.js
+++ b/packages/mjml-browser/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     path: path.resolve(__dirname, './lib'),
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    globalObject: 'this',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Update webpack `output.globalObject` to support environments without `window` and fix https://github.com/mjmlio/mjml/issues/2853