### PR TITLE
bugfix(mj-wrapper): displays too wide with padding #3019

### DIFF
--- a/packages/mjml-wrapper/src/index.js
+++ b/packages/mjml-wrapper/src/index.js
@@ -9,13 +9,6 @@ export default class MjWrapper extends MjSection {
     gap: 'unit(px)',
   }
 
-  getChildContext() {
-    return {
-      ...this.context,
-      gap: this.getAttribute('gap'),
-    }
-  }
-
   renderWrappedChildren() {
     const { children } = this.props
     const { containerWidth } = this.context


### PR DESCRIPTION
**What:**
When adding `padding` to `mj-wrapper`, the padding is added to the width, rather than subtracted from it.

**Why:**
`mj-section` now inherits width from `mj-wrapper` rather than working out its own. Introduced by https://github.com/mjmlio/mjml/pull/3004 in 4.17.0

**How:**
Removed offending code added in previous release. 

fixes #3019 
