### PR TITLE
docs(mj-wrapper): option descriptions switched #3031

### DIFF
--- a/packages/mjml-wrapper/README.md
+++ b/packages/mjml-wrapper/README.md
@@ -49,7 +49,7 @@ Setting it will change the width of the section from the default 600px to 100%.
 | background-position   | string                  | CSS values, i.e. `left` `center` `right` + `top` `center` `bottom` <br>(see outlook limitations below) | `top center`  |
 | background-position-x | string                  | CSS values, i.e. `left` `center` `right` <br>(see outlook limitations below)                           |               |
 | background-position-y | string                  | CSS values, i.e. `top` `center` `bottom` <br>(see outlook limitations below)                           |               |
-| background-repeat     | `repeat` `no-repeat`    | set the background image to repeat                                                                     |
+| background-repeat     | `repeat` `no-repeat`    | set the background image to repeat                                                                     |               |
 | background-size       | string                  | CSS values e.g. `auto` `cover` `contain` `px` `%` size                                                 | `auto`        |
 | background-url        | string                  | background image, in URL format                                                                        |               |
 | border                | string                  | CSS border format                                                                                      |               |
@@ -59,8 +59,8 @@ Setting it will change the width of the section from the default 600px to 100%.
 | border-right          | string                  | CSS border format                                                                                      |               |
 | border-top            | string                  | CSS border format                                                                                      |               |
 | css-class             | string                  | class name, added to the root HTML element created                                                     |               |
-| full-width            | `full-width` `false`    | applies a vertical gap between child `mj-section` instances                                            |               |
-| gap                   | `px`                    | make the section full-width                                                                            |               |
+| full-width            | `full-width` `false`    | make the section full-width                                                                            |               |
+| gap                   | `px`                    | applies a vertical gap between child `mj-section` instances                                            |               |
 | padding               | `px` `%`                | section padding, supports up to 4 parameters                                                           | `20px 0`      |
 | padding-bottom        | `px` `%`                | section bottom padding                                                                                 |               |
 | padding-left          | `px` `%`                | section left padding                                                                                   |               |


### PR DESCRIPTION
Descriptions of the options `full-width` and `gap` were incorrectly switched.

Fixes #3031