### PR TITLE
chore(mjml build): various warnings addressed

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,6 +15,5 @@ module.exports = {
       },
     ],
     'add-module-exports',
-    'lodash',
   ],
 }

--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,11 @@
   "command": {
     "publish": {
       "exact": true
+    },
+    "run": {
+      "stream": true,
+      "parallel": true,
+      "concurrency": 1
     }
   },
   "npmClient": "yarn",

--- a/packages/mjml-parser-xml/src/helpers/cleanNode.js
+++ b/packages/mjml-parser-xml/src/helpers/cleanNode.js
@@ -1,11 +1,11 @@
-import _ from 'lodash'
+import forEach from 'lodash/forEach'
 
 export default function cleanNode(node) {
   delete node.parent
 
   // Delete children if needed
   if (node.children && node.children.length) {
-    _.forEach(node.children, cleanNode)
+    forEach(node.children, cleanNode)
   } else {
     delete node.children
   }


### PR DESCRIPTION
- Removed lodash from the plugins array in babel.config.js to prevent deprecated isModuleDeclaration and replaced with a method-level import in cleanNode.js
- Updated testing to remove dependency cycles