### PR TITLE
bugfix(mjml-accordion): mj-accordion closed in new Outlook

### DIFF
--- a/packages/mjml-accordion/src/Accordion.js
+++ b/packages/mjml-accordion/src/Accordion.js
@@ -42,13 +42,13 @@ export default class MjAccordion extends BodyComponent {
 
       @media yahoo, only screen and (min-width:0) {
         .mj-accordion-element { display:block; }
-        input.mj-accordion-checkbox, .mj-accordion-less { display:none!important; }
-        input.mj-accordion-checkbox + * .mj-accordion-title { cursor:pointer; touch-action:manipulation; -webkit-user-select:none; -moz-user-select:none; user-select:none; }
-        input.mj-accordion-checkbox + * .mj-accordion-content { overflow:hidden; display:none; }
-        input.mj-accordion-checkbox + * .mj-accordion-more { display:block!important; }
-        input.mj-accordion-checkbox:checked + * .mj-accordion-content { display:block; }
-        input.mj-accordion-checkbox:checked + * .mj-accordion-more { display:none!important; }
-        input.mj-accordion-checkbox:checked + * .mj-accordion-less { display:block!important; }
+        .mj-accordion-checkbox[type="checkbox"], .mj-accordion-less { display:none!important; }
+        .mj-accordion-checkbox[type="checkbox"] + * .mj-accordion-title { cursor:pointer; touch-action:manipulation; -webkit-user-select:none; -moz-user-select:none; user-select:none; }
+        .mj-accordion-checkbox[type="checkbox"] + * .mj-accordion-content { overflow:hidden; display:none; }
+        .mj-accordion-checkbox[type="checkbox"] + * .mj-accordion-more { display:block!important; }
+        .mj-accordion-checkbox:checked + * .mj-accordion-content { display:block; }
+        .mj-accordion-checkbox:checked + * .mj-accordion-more { display:none!important; }
+        .mj-accordion-checkbox:checked + * .mj-accordion-less { display:block!important; }
       }
 
       .moz-text-html input.mj-accordion-checkbox + * .mj-accordion-title { cursor: auto; touch-action: auto; -webkit-user-select: auto; -moz-user-select: auto; user-select: auto; }


### PR DESCRIPTION
- Updated CSS to fix an issue whereby the accordion was closed in all versions of new Outlook

Fixes: #3086