### PR TITLE
docs(head-attributes): fix wuthin typo

### DIFF
--- a/packages/mjml-head-attributes/README.md
+++ b/packages/mjml-head-attributes/README.md
@@ -35,7 +35,7 @@ components using `mj-class="<name>"`.
   <ul>
     <li>inline attributes within tags,</li>
     <li>attributes found in tags within the <code>mj-attributes</code> tag, e.g. <code>mj-text</code>,</li>
-    <li>the <code>mj-all</code> tag wuthin <code>mj-attributes</code>, and</li>
+    <li>the <code>mj-all</code> tag within <code>mj-attributes</code>, and</li>
     <li>the default MJML values.</li>
   </ul>
 </div>


### PR DESCRIPTION
## Summary

Closes #3094. Fix the `wuthin` -> `within` typo in `packages/mjml-head-attributes/README.md:38`. The same line is reflected verbatim on the public docs at documentation.mjml.io/#mj-attributes, so both surfaces will read correctly after this merges.

## Why this matters

The attribute resolution order is one of the first things a contributor reads when picking up `mj-attributes`. A typo there reads as un-cared-for and slightly undermines the rest of the doc. The reporter caught it on the live docs page; the source lives in this package's README.

Single-character edit. No code or runtime behavior change.

## How to test

```
$ grep -n wuthin packages/mjml-head-attributes/README.md
(empty)
$ grep -n "tag within \`mj-attributes\`" packages/mjml-head-attributes/README.md
38:    <li>the <code>mj-all</code> tag within <code>mj-attributes</code>, and</li>
```

Fixes #3094

AI-assisted.
