### PR TITLE
ci(checkout): upgrade checkout/setup-node actions and set Node24 JS actions runtime

### DIFF
--- a/.github/workflows/mjml-workflow.yml
+++ b/.github/workflows/mjml-workflow.yml
@@ -1,5 +1,7 @@
 name: Mjml CI
 on: [push, pull_request]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -7,9 +9,9 @@ jobs:
       matrix:
         node-version: [20.x, 22.x, 24.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run linting & tests
@@ -22,9 +24,9 @@ jobs:
   browser-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
       - name: Build browser bundle + smoke test


### PR DESCRIPTION
## What's changed

- upgrade GitHub Actions versions in CI workflows:
  - actions/checkout from v2 to v5
  - actions/setup-node from v1 to v4

- add workflow-level env FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true