### PR TITLE
feat(mjml-social): add border attribute to mj-social-element

### DIFF
--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -41,6 +41,7 @@ Displays calls-to-action for various social networks with their associated logo.
 | attribute                  | accepts                 | description                                        | default value                          |
 | -------------------------- | ----------------------- | -------------------------------------------------- | -------------------------------------- |
 | align                      | `left` `right` `center` | align content                                      | `center`                               |
+| border                     | string                  | icon border, applied to each `mj-social-element`   |                                        |
 | border-radius              | `px` `%`                | border radius                                      | `3px`                                  |
 | color                      | CSS color formats       | text color                                         | `#333333`                              |
 | css-class                  | string                  | class name, added to the root HTML element created |                                        |
@@ -84,6 +85,7 @@ Note that default icons are transparent, which allows `background-color` to actu
 | align            | `left` `center` `right` | align content                                                                   | `center`                               |
 | alt              | string                  | image alt attribute                                                             | `''`                                   |
 | background-color | CSS color formats       | icon color                                                                      | Each social `name` has its own default |
+| border           | string                  | icon border (CSS shorthand), applied to the `<img>`                             | `0`                                    |
 | border-radius    | string                  | border radius                                                                   | `3px`                                  |
 | color            | CSS color formats       | text color                                                                      | `#000`                                 |
 | css-class        | string                  | class name, added to the root HTML element created                              |                                        |

--- a/packages/mjml-social/src/Social.js
+++ b/packages/mjml-social/src/Social.js
@@ -6,6 +6,7 @@ export default class MjSocial extends BodyComponent {
 
   static allowedAttributes = {
     align: 'enum(left,right,center)',
+    border: 'string',
     'border-radius': 'string',
     'container-background-color': 'color',
     color: 'color',
@@ -60,6 +61,7 @@ export default class MjSocial extends BodyComponent {
     }
 
     return [
+      'border',
       'border-radius',
       'color',
       'font-family',

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -102,6 +102,7 @@ export default class MjSocialElement extends BodyComponent {
     'icon-position': 'enum(left,right)',
     'background-color': 'color',
     color: 'color',
+    border: 'string',
     'border-radius': 'string',
     'font-family': 'string',
     'font-size': 'unit(px)',
@@ -135,6 +136,7 @@ export default class MjSocialElement extends BodyComponent {
     align: 'left',
     'icon-position': 'left',
     color: '#000',
+    border: '0',
     'border-radius': '3px',
     'font-family': 'Ubuntu, Helvetica, Arial, sans-serif',
     'font-size': '13px',
@@ -175,6 +177,7 @@ export default class MjSocialElement extends BodyComponent {
         width: iconSize,
       },
       img: {
+        border: this.getAttribute('border'),
         'border-radius': this.getAttribute('border-radius'),
         display: 'block',
       },

--- a/packages/mjml/test/social-border.test.js
+++ b/packages/mjml/test/social-border.test.js
@@ -3,11 +3,42 @@ const { load } = require('cheerio')
 const mjml = require('../lib')
 const { extractStyle } = require('./utils')
 
-const render = async (template) => mjml(template, { minify: false })
+// Each mj-social-element in these tests carries this css-class, which MJML
+// renders onto the element's <tr>. Scoping the border selector to that row
+// guarantees we only inspect social icon images, never an unrelated <img>
+// elsewhere in the document.
+const SOCIAL_ICON_CLASS = 'mj-social-border-test'
 
-const collectImgBorders = (html) => {
+const renderSocial = ({ mode = 'horizontal', socialBorder, elements }) => {
+  const socialBorderAttr = socialBorder ? ` border="${socialBorder}"` : ''
+  const children = elements
+    .map(({ name, border }) => {
+      const borderAttr = border ? ` border="${border}"` : ''
+      return `<mj-social-element css-class="${SOCIAL_ICON_CLASS}" name="${name}" href="https://mjml.io/"${borderAttr} />`
+    })
+    .join('\n              ')
+
+  return mjml(
+    `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-social mode="${mode}"${socialBorderAttr}>
+              ${children}
+              </mj-social>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `,
+    { minify: false },
+  )
+}
+
+const collectSocialBorders = (html) => {
   const $ = load(html)
-  return $('img')
+  return $(`tr.${SOCIAL_ICON_CLASS} img`)
     .map(function getBorder() {
       const style = $(this).attr('style') || ''
       return extractStyle(style, 'border')
@@ -17,93 +48,68 @@ const collectImgBorders = (html) => {
 
 describe('mj-social-element border attribute', function () {
   it('renders the default border:0 on each social-element <img>', async function () {
-    const input = `
-      <mjml>
-        <mj-body>
-          <mj-section>
-            <mj-column>
-              <mj-social>
-                <mj-social-element name="facebook" href="https://mjml.io/" />
-                <mj-social-element name="twitter" href="https://mjml.io/" />
-              </mj-social>
-            </mj-column>
-          </mj-section>
-        </mj-body>
-      </mjml>
-    `
-
-    const { html } = await render(input)
-    const borders = collectImgBorders(html)
+    const { html } = await renderSocial({
+      elements: [{ name: 'facebook' }, { name: 'twitter' }],
+    })
+    const borders = collectSocialBorders(html)
 
     chai.expect(borders).to.have.lengthOf(2)
     borders.forEach((b) => chai.expect(b).to.equal('0'))
   })
 
   it('honors an explicit border on a single mj-social-element', async function () {
-    const input = `
-      <mjml>
-        <mj-body>
-          <mj-section>
-            <mj-column>
-              <mj-social>
-                <mj-social-element name="facebook" href="https://mjml.io/" border="2px solid red" />
-                <mj-social-element name="twitter" href="https://mjml.io/" />
-              </mj-social>
-            </mj-column>
-          </mj-section>
-        </mj-body>
-      </mjml>
-    `
-
-    const { html } = await render(input)
-    const borders = collectImgBorders(html)
+    const { html } = await renderSocial({
+      elements: [
+        { name: 'facebook', border: '2px solid red' },
+        { name: 'twitter' },
+      ],
+    })
+    const borders = collectSocialBorders(html)
 
     chai.expect(borders).to.deep.equal(['2px solid red', '0'])
   })
 
   it('cascades a border set on mj-social to every child element', async function () {
-    const input = `
-      <mjml>
-        <mj-body>
-          <mj-section>
-            <mj-column>
-              <mj-social border="1px solid #ccc">
-                <mj-social-element name="facebook" href="https://mjml.io/" />
-                <mj-social-element name="twitter" href="https://mjml.io/" />
-                <mj-social-element name="linkedin" href="https://mjml.io/" />
-              </mj-social>
-            </mj-column>
-          </mj-section>
-        </mj-body>
-      </mjml>
-    `
-
-    const { html } = await render(input)
-    const borders = collectImgBorders(html)
+    const { html } = await renderSocial({
+      socialBorder: '1px solid #ccc',
+      elements: [
+        { name: 'facebook' },
+        { name: 'twitter' },
+        { name: 'linkedin' },
+      ],
+    })
+    const borders = collectSocialBorders(html)
 
     chai.expect(borders).to.have.lengthOf(3)
     borders.forEach((b) => chai.expect(b).to.equal('1px solid #ccc'))
   })
 
   it('lets the element-level border override a cascaded border from mj-social', async function () {
-    const input = `
-      <mjml>
-        <mj-body>
-          <mj-section>
-            <mj-column>
-              <mj-social border="1px solid #ccc">
-                <mj-social-element name="facebook" href="https://mjml.io/" border="3px dashed #000" />
-                <mj-social-element name="twitter" href="https://mjml.io/" />
-              </mj-social>
-            </mj-column>
-          </mj-section>
-        </mj-body>
-      </mjml>
-    `
-
-    const { html } = await render(input)
-    const borders = collectImgBorders(html)
+    const { html } = await renderSocial({
+      socialBorder: '1px solid #ccc',
+      elements: [
+        { name: 'facebook', border: '3px dashed #000' },
+        { name: 'twitter' },
+      ],
+    })
+    const borders = collectSocialBorders(html)
 
     chai.expect(borders).to.deep.equal(['3px dashed #000', '1px solid #ccc'])
+  })
+
+  it('applies cascade and element override in vertical mode (different markup)', async function () {
+    // mj-social compiles a separate layout for mode="vertical", so the border
+    // cascade and element-level override are exercised independently here.
+    const { html } = await renderSocial({
+      mode: 'vertical',
+      socialBorder: '1px solid #ccc',
+      elements: [
+        { name: 'facebook' },
+        { name: 'twitter', border: '2px solid red' },
+      ],
+    })
+    const borders = collectSocialBorders(html)
+
+    chai.expect(borders).to.deep.equal(['1px solid #ccc', '2px solid red'])
   })
 })

--- a/packages/mjml/test/social-border.test.js
+++ b/packages/mjml/test/social-border.test.js
@@ -1,0 +1,109 @@
+const chai = require('chai')
+const { load } = require('cheerio')
+const mjml = require('../lib')
+const { extractStyle } = require('./utils')
+
+const render = async (template) => mjml(template, { minify: false })
+
+const collectImgBorders = (html) => {
+  const $ = load(html)
+  return $('img')
+    .map(function getBorder() {
+      const style = $(this).attr('style') || ''
+      return extractStyle(style, 'border')
+    })
+    .get()
+}
+
+describe('mj-social-element border attribute', function () {
+  it('renders the default border:0 on each social-element <img>', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-social>
+                <mj-social-element name="facebook" href="https://mjml.io/" />
+                <mj-social-element name="twitter" href="https://mjml.io/" />
+              </mj-social>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html } = await render(input)
+    const borders = collectImgBorders(html)
+
+    chai.expect(borders).to.have.lengthOf(2)
+    borders.forEach((b) => chai.expect(b).to.equal('0'))
+  })
+
+  it('honors an explicit border on a single mj-social-element', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-social>
+                <mj-social-element name="facebook" href="https://mjml.io/" border="2px solid red" />
+                <mj-social-element name="twitter" href="https://mjml.io/" />
+              </mj-social>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html } = await render(input)
+    const borders = collectImgBorders(html)
+
+    chai.expect(borders).to.deep.equal(['2px solid red', '0'])
+  })
+
+  it('cascades a border set on mj-social to every child element', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-social border="1px solid #ccc">
+                <mj-social-element name="facebook" href="https://mjml.io/" />
+                <mj-social-element name="twitter" href="https://mjml.io/" />
+                <mj-social-element name="linkedin" href="https://mjml.io/" />
+              </mj-social>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html } = await render(input)
+    const borders = collectImgBorders(html)
+
+    chai.expect(borders).to.have.lengthOf(3)
+    borders.forEach((b) => chai.expect(b).to.equal('1px solid #ccc'))
+  })
+
+  it('lets the element-level border override a cascaded border from mj-social', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-social border="1px solid #ccc">
+                <mj-social-element name="facebook" href="https://mjml.io/" border="3px dashed #000" />
+                <mj-social-element name="twitter" href="https://mjml.io/" />
+              </mj-social>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html } = await render(input)
+    const borders = collectImgBorders(html)
+
+    chai.expect(borders).to.deep.equal(['3px dashed #000', '1px solid #ccc'])
+  })
+})


### PR DESCRIPTION
Fixes #2466.

Email accessibility tooling (Email on Acid, Litmus) flags `<img>` tags in social blocks for missing `border` attributes. `mj-image` already supports a `border` attribute that renders as CSS on the resulting `<img>`; `mj-social-element` did not, leaving no way to set or default it without copying the rendered HTML out by hand.

### Changes

- **`packages/mjml-social/src/SocialElement.js`**
  - Add `border: 'string'` to `allowedAttributes`
  - Add `border: '0'` to `defaultAttributes` (matches `mj-image`'s default)
  - Add `border: this.getAttribute('border')` to the `img` styles in `getStyles()`
- **`packages/mjml-social/src/Social.js`**
  - Add `border: 'string'` to `allowedAttributes`
  - Add `border` to the cascade list in `getSocialElementAttributes` so a single declaration on `mj-social` applies to every child. Element-level borders still take precedence.
- **`packages/mjml-social/README.md`**
  - New `border` rows in both attribute tables
- **`packages/mjml/test/social-border.test.js`** (new)
  - Four cases: default `0` on every element, explicit element override, parent cascade, and element-overrides-cascade

### Sample rendered output

With:
```xml
<mj-social border="1px solid #ccc">
  <mj-social-element name="facebook" href="https://mjml.io/" />
  <mj-social-element name="x" href="https://mjml.io/" border="2px solid red" />
  <mj-social-element name="linkedin" href="https://mjml.io/" />
</mj-social>
```

The three `<img>` tags emit:
- `style="border:1px solid #ccc;border-radius:3px;display:block;"` (cascaded)
- `style="border:2px solid red;border-radius:3px;display:block;"` (element override)
- `style="border:1px solid #ccc;border-radius:3px;display:block;"` (cascaded)

### Verification

- `yarn build` ✓ all packages
- `yarn test` ✓ 74 → 78 (the 4 new cases)
- Lint clean on changed files