### PR TITLE
Add emjay to community ports

### DIFF
--- a/doc/ports.md
+++ b/doc/ports.md
@@ -26,6 +26,12 @@ Native Implemented Function (NIF) bindings for the MJML Rust implementation (mrm
 
 [https://github.com/adoptoposs/mjml_nif](https://github.com/adoptoposs/mjml_nif)
 
+### Ruby: Emjay
+
+A pure-Ruby MJML parser and processor based on Nokogiri. Comes with a builtin ActionMailer interceptor for rendering Rails emails.
+
+[https://github.com/julik/emjay]([https://github.com/hardpixel/mrml-ruby](https://github.com/julik/emjay)
+
 ### Ruby: MRML Ruby
 
 Ruby wrapper for MRML, the MJML markup language implementation in Rust.


### PR DESCRIPTION
Added information about the emjay Ruby parser and processor for MJML. I needed to experiment with MJML but found the Ruby ports a bit lacking - they all need dependencies, so a quick vibe-port was done based on using Nokogiri to parse MJML as if it were an HTML/XML hybrid. Seems to be working well enough.