### PR TITLE
feature(mj-section): added gutter attribute to add space between columns

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -81,7 +81,7 @@ Let's take the following layout to illustrate this:
 
 #### Section gutter
 
-To add consistent spacing around and between columns, set a `gutter` on `mj-section`. The gutter is declared on the section and applies to all of its columns.
+To add consistent spacing between columns, set a `gutter` on `mj-section`. The gutter is declared on the section and applies to all of its columns.
 
 ```html
 <mjml>
@@ -100,4 +100,6 @@ To add consistent spacing around and between columns, set a `gutter` on `mj-sect
 
 When stacked in a single column on mobile, the gutter will display vertically between the columns.
 
-**Note:** the gutter is automatically removed from any declared width on `mj-column`. You do not need to work the values out yourself. e.g. if you declare a `4%` gutter and two `mj-column` instances with `50%` width each then the actual displayed width of the column will be 44% with 4% gutters between the two columns and 4% at each side.
+**Note:** the gutter is automatically removed from any declared width on `mj-column`. You do not need to work the values out yourself. e.g. if you declare a `4%` gutter and two `mj-column` instances with `50%` width each then the actual displayed width of the column will be 48% with 2% gutters between the two columns.
+
+You can use the existing `padding` attribute to set spacing between the end columns and the edges.

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -78,3 +78,26 @@ Let's take the following layout to illustrate this:
   </mj-body>
 </mjml>
 ```
+
+#### Section gutter
+
+To add consistent spacing around and between columns, set a `gutter` on `mj-section`. The gutter is declared on the section and applies to all of its columns.
+
+```html
+<mjml>
+  <mj-body>
+    <mj-section gutter="4%">
+      <mj-column>
+        <!-- First column content -->
+      </mj-column>
+      <mj-column>
+        <!-- Second column content -->
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+```
+
+When stacked in a single column on mobile, the gutter will display vertically between the columns.
+
+**Note:** the gutter is automatically removed from any declared width on `mj-column`. You do not need to work the values out yourself. e.g. if you declare a `4%` gutter and two `mj-column` instances with `50%` width each then the actual displayed width of the column will be 44% with 4% gutters between the two columns and 4% at each side.

--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -127,20 +127,24 @@ export default class MjColumn extends BodyComponent {
   }
 
   getMobileWidth() {
-    const { containerWidth } = this.context
+    const { containerWidth, isInGroup } = this.context
     const { nonRawSiblings } = this.props
     const width = this.getAttribute('width')
     const mobileWidth = this.getAttribute('mobileWidth')
 
     if (mobileWidth !== 'mobileWidth') {
-      const gutter = this.getNormalizedGutterValue('%')
-
-      if (gutter > 0) {
-          return `${MjColumn.normalizeUnitValue(100 - 2 * gutter)}%`
-      }
-
       return '100%'
     }
+
+    // Group columns don't stack on mobile, so use gutter-reduced desktop width
+    if (isInGroup && this.hasColumnGutter()) {
+      const { parsedWidth, unit } = this.getDesktopWidth()
+      if (unit === '%') {
+        return `${parsedWidth}%`
+      }
+      return `${MjColumn.normalizeUnitValue((parsedWidth / parseInt(containerWidth, 10)) * 100)}%`
+    }
+
     if (width === undefined) {
       return `${parseInt(100 / nonRawSiblings, 10)}%`
     }
@@ -150,21 +154,13 @@ export default class MjColumn extends BodyComponent {
     })
 
     switch (unit) {
-      case '%': {
-        const gutter = this.getNormalizedGutterValue('%')
-
-        if (gutter > 0) {
-          return `${MjColumn.normalizeUnitValue(parsedWidth - 2 * gutter)}%`
-        }
-
+      case '%':
         return width
-      }
       case 'px':
       default:
         return `${
           MjColumn.normalizeUnitValue(
-            (parsedWidth / parseInt(containerWidth, 10)) * 100 -
-              2 * this.getNormalizedGutterValue('%'),
+            (parsedWidth / parseInt(containerWidth, 10)) * 100,
           )
         }%`
     }
@@ -178,9 +174,9 @@ export default class MjColumn extends BodyComponent {
     })
 
     if (unit === '%') {
-      return `${(parseFloat(containerWidth) * parsedWidth) / 100}px`
+      return `${MjColumn.normalizePxValue((parseFloat(containerWidth) * parsedWidth) / 100)}px`
     }
-    return `${parsedWidth}px`
+    return `${MjColumn.normalizePxValue(parsedWidth)}px`
   }
 
   getParsedWidth(toString) {
@@ -204,13 +200,16 @@ export default class MjColumn extends BodyComponent {
 
   getColumnClass() {
     const { addMediaQuery } = this.context
+    const { isInGroup } = this.context
 
     let className = ''
 
     const { parsedWidth, unit } = this.hasColumnGutter()
       ? this.getDesktopWidth()
       : this.getParsedWidth()
-    const formattedClassNb = parsedWidth.toString().replace('.', '-')
+    const normalizedParsedWidth =
+      unit === 'px' ? MjColumn.normalizePxValue(parsedWidth) : parsedWidth
+    const formattedClassNb = normalizedParsedWidth.toString().replace('.', '-')
 
     switch (unit) {
       case '%':
@@ -226,16 +225,19 @@ export default class MjColumn extends BodyComponent {
     // Add className to media queries
     if (this.hasColumnGutter()) {
       addMediaQuery(className, {
-        parsedWidth,
+        parsedWidth: normalizedParsedWidth,
         unit,
       })
 
-      addMediaQuery(this.getDesktopGutterClassName(), {
-        padding: this.getDesktopPadding(),
-      })
+      // Group columns already carry gutter padding inline; avoid duplicate media-query rules
+      if (!isInGroup) {
+        addMediaQuery(this.getDesktopGutterClassName(), {
+          padding: this.getDesktopPadding(),
+        })
+      }
     } else {
       addMediaQuery(className, {
-        parsedWidth,
+        parsedWidth: normalizedParsedWidth,
         unit,
       })
     }
@@ -247,12 +249,15 @@ export default class MjColumn extends BodyComponent {
     const gutterUnit = this.getDesktopUnit()
     const gutter = this.getNormalizedGutterValue(gutterUnit)
     const gutterUnitToken = gutterUnit === '%' ? 'per' : gutterUnit
+    const directionToken = this.context.direction === 'rtl' ? '-rtl' : ''
+    const normalizedGutter =
+      gutterUnit === 'px' ? MjColumn.normalizePxValue(gutter) : gutter
 
-    const gutterToken = MjColumn.normalizeUnitValue(gutter)
+    const gutterToken = MjColumn.normalizeUnitValue(normalizedGutter)
       .toString()
       .replace('.', '-')
 
-    return `mj-column-gutter-${this.props.sibling}-${this.props.index + 1}-${gutterUnitToken}-${gutterToken}`
+    return `mj-column-gutter-${this.props.sibling}-${this.props.index + 1}-${gutterUnitToken}-${gutterToken}${directionToken}`
   }
 
   getDesktopUnit() {
@@ -260,27 +265,44 @@ export default class MjColumn extends BodyComponent {
   }
 
   getDesktopWidth() {
-    const { sibling } = this.props
+    const { sibling, index } = this.props
     const { parsedWidth, unit } = this.getParsedWidth()
 
     if (!this.hasColumnGutter()) {
-      return { parsedWidth, unit }
+      return {
+        parsedWidth: unit === 'px' ? MjColumn.normalizePxValue(parsedWidth) : parsedWidth,
+        unit,
+      }
     }
 
     const gutter = this.getNormalizedGutterValue(unit)
-    const reduction = (gutter * (sibling + 1)) / sibling
+    const reduction = (gutter * (sibling - 1)) / sibling
+
+    const reducedWidth = Math.max(0, MjColumn.normalizeUnitValue(parsedWidth - reduction))
+
+    if (unit === 'px') {
+      const floorWidth = Math.floor(reducedWidth)
+      const fractional = reducedWidth - floorWidth
+      const extraPixels = Math.max(0, Math.min(sibling, Math.round(sibling * fractional)))
+
+      return {
+        parsedWidth: floorWidth + (index < extraPixels ? 1 : 0),
+        unit,
+      }
+    }
 
     return {
-      parsedWidth: Math.max(
-        0,
-        MjColumn.normalizeUnitValue(parsedWidth - reduction),
-      ),
+      parsedWidth: reducedWidth,
       unit,
     }
   }
 
   static normalizeUnitValue(value) {
     return Number(parseFloat(value).toFixed(6))
+  }
+
+  static normalizePxValue(value) {
+    return Math.round(parseFloat(value))
   }
 
   getNormalizedGutterValue(targetUnit) {
@@ -318,49 +340,68 @@ export default class MjColumn extends BodyComponent {
 
   getDesktopPaddingValues(unit) {
     const { first, last, sibling } = this.props
+    const { direction } = this.context
     const gutter = this.getNormalizedGutterValue(unit)
-    const half = gutter / 2
+    const normalizedGutter =
+      unit === 'px' ? MjColumn.normalizePxValue(gutter) : gutter
+    const isPx = unit === 'px'
+    const halfLeading = isPx ? Math.ceil(normalizedGutter / 2) : normalizedGutter / 2
+    const halfTrailing = isPx
+      ? Math.floor(normalizedGutter / 2)
+      : normalizedGutter / 2
+    const isRTL = direction === 'rtl'
 
     if (sibling === 1) {
       return {
         top: 0,
-        right: gutter,
+        right: 0,
         bottom: 0,
-        left: gutter,
+        left: 0,
+      }
+    }
+
+    // When RTL, first/last visual positions are reversed
+    if (isRTL) {
+      return {
+        top: 0,
+        right: first ? 0 : halfTrailing,
+        bottom: 0,
+        left: last ? 0 : halfLeading,
       }
     }
 
     return {
       top: 0,
-      right: last ? gutter : half,
+      right: last ? 0 : halfLeading,
       bottom: 0,
-      left: first ? gutter : half,
+      left: first ? 0 : halfTrailing,
     }
   }
 
   getMobilePaddingValues() {
-    const { first, last, sibling } = this.props
+    const { first, last } = this.props
     const gutter = this.getNormalizedGutterValue('%')
     const half = gutter / 2
 
-    if (sibling === 1) {
-      return {
-        top: 0,
-        right: gutter,
-        bottom: 0,
-        left: gutter,
-      }
-    }
-
+    // On mobile: gutter appears as vertical spacing between stacked columns,
+    // but not on outer left/right edges
     return {
       top: first ? 0 : half,
-      right: gutter,
+      right: 0,
       bottom: last ? 0 : half,
-      left: gutter,
+      left: 0,
     }
   }
 
   static formatPadding(top, right, bottom, left, unit) {
+    if (unit === 'px') {
+      return `${MjColumn.normalizePxValue(top)}px ${MjColumn.normalizePxValue(
+        right,
+      )}px ${MjColumn.normalizePxValue(bottom)}px ${MjColumn.normalizePxValue(
+        left,
+      )}px`
+    }
+
     return `${MjColumn.normalizeUnitValue(top)}${unit} ${MjColumn.normalizeUnitValue(
       right,
     )}${unit} ${MjColumn.normalizeUnitValue(bottom)}${unit} ${
@@ -386,6 +427,16 @@ export default class MjColumn extends BodyComponent {
       return {}
     }
 
+    const { isInGroup } = this.context
+
+    // Group columns don't stack on mobile, so maintain desktop horizontal padding
+    if (isInGroup) {
+      return {
+        padding: this.getDesktopPadding(),
+      }
+    }
+
+    // Regular columns: vertical spacing between stacked columns
     return {
       padding: this.getMobilePadding(),
     }

--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -83,6 +83,9 @@ export default class MjColumn extends BodyComponent {
       ...(hasBorderRadius && { 'border-collapse': 'separate' }),
     }
 
+    const mobileGutterStyles = this.getMobileGutterStyles()
+    const outlookGutterStyles = this.getOutlookGutterStyles()
+
     return {
       div: {
         'font-size': '0px',
@@ -91,6 +94,7 @@ export default class MjColumn extends BodyComponent {
         display: 'inline-block',
         'vertical-align': this.getAttribute('vertical-align'),
         width: this.getMobileWidth(),
+        ...mobileGutterStyles,
       },
       table: {
         ...(this.hasGutter()
@@ -109,6 +113,7 @@ export default class MjColumn extends BodyComponent {
       tdOutlook: {
         'vertical-align': this.getAttribute('vertical-align'),
         width: this.getWidthAsPixel(),
+        ...outlookGutterStyles,
       },
       gutter: {
         ...tableStyle,
@@ -128,6 +133,12 @@ export default class MjColumn extends BodyComponent {
     const mobileWidth = this.getAttribute('mobileWidth')
 
     if (mobileWidth !== 'mobileWidth') {
+      const gutter = this.getNormalizedGutterValue('%')
+
+      if (gutter > 0) {
+          return `${MjColumn.normalizeUnitValue(100 - 2 * gutter)}%`
+      }
+
       return '100%'
     }
     if (width === undefined) {
@@ -139,11 +150,23 @@ export default class MjColumn extends BodyComponent {
     })
 
     switch (unit) {
-      case '%':
+      case '%': {
+        const gutter = this.getNormalizedGutterValue('%')
+
+        if (gutter > 0) {
+          return `${MjColumn.normalizeUnitValue(parsedWidth - 2 * gutter)}%`
+        }
+
         return width
+      }
       case 'px':
       default:
-        return `${(parsedWidth / parseInt(containerWidth, 10)) * 100}%`
+        return `${
+          MjColumn.normalizeUnitValue(
+            (parsedWidth / parseInt(containerWidth, 10)) * 100 -
+              2 * this.getNormalizedGutterValue('%'),
+          )
+        }%`
     }
   }
 
@@ -184,7 +207,9 @@ export default class MjColumn extends BodyComponent {
 
     let className = ''
 
-    const { parsedWidth, unit } = this.getParsedWidth()
+    const { parsedWidth, unit } = this.hasColumnGutter()
+      ? this.getDesktopWidth()
+      : this.getParsedWidth()
     const formattedClassNb = parsedWidth.toString().replace('.', '-')
 
     switch (unit) {
@@ -199,13 +224,186 @@ export default class MjColumn extends BodyComponent {
     }
 
     // Add className to media queries
-    addMediaQuery(className, {
-      parsedWidth,
-      unit,
-    })
+    if (this.hasColumnGutter()) {
+      addMediaQuery(className, {
+        parsedWidth,
+        unit,
+      })
+
+      addMediaQuery(this.getDesktopGutterClassName(), {
+        padding: this.getDesktopPadding(),
+      })
+    } else {
+      addMediaQuery(className, {
+        parsedWidth,
+        unit,
+      })
+    }
 
     return className
   }
+
+  getDesktopGutterClassName() {
+    const gutterUnit = this.getDesktopUnit()
+    const gutter = this.getNormalizedGutterValue(gutterUnit)
+    const gutterUnitToken = gutterUnit === '%' ? 'per' : gutterUnit
+
+    const gutterToken = MjColumn.normalizeUnitValue(gutter)
+      .toString()
+      .replace('.', '-')
+
+    return `mj-column-gutter-${this.props.sibling}-${this.props.index + 1}-${gutterUnitToken}-${gutterToken}`
+  }
+
+  getDesktopUnit() {
+    return this.getParsedWidth().unit
+  }
+
+  getDesktopWidth() {
+    const { sibling } = this.props
+    const { parsedWidth, unit } = this.getParsedWidth()
+
+    if (!this.hasColumnGutter()) {
+      return { parsedWidth, unit }
+    }
+
+    const gutter = this.getNormalizedGutterValue(unit)
+    const reduction = (gutter * (sibling + 1)) / sibling
+
+    return {
+      parsedWidth: Math.max(
+        0,
+        MjColumn.normalizeUnitValue(parsedWidth - reduction),
+      ),
+      unit,
+    }
+  }
+
+  static normalizeUnitValue(value) {
+    return Number(parseFloat(value).toFixed(6))
+  }
+
+  getNormalizedGutterValue(targetUnit) {
+    const { gutter } = this.context
+
+    if (!gutter) {
+      return 0
+    }
+
+    const { containerWidth } = this.context
+    const { unit, parsedWidth } = widthParser(gutter, {
+      parseFloatToInt: false,
+    })
+
+    if (unit === targetUnit) {
+      return parsedWidth
+    }
+
+    if (targetUnit === '%' && unit === 'px') {
+      return (parsedWidth / parseFloat(containerWidth)) * 100
+    }
+
+    if (targetUnit === 'px' && unit === '%') {
+      return (parseFloat(containerWidth) * parsedWidth) / 100
+    }
+
+    return parsedWidth
+  }
+
+  hasColumnGutter() {
+    const { gutter } = this.context
+
+    return gutter != null && gutter !== ''
+  }
+
+  getDesktopPaddingValues(unit) {
+    const { first, last, sibling } = this.props
+    const gutter = this.getNormalizedGutterValue(unit)
+    const half = gutter / 2
+
+    if (sibling === 1) {
+      return {
+        top: 0,
+        right: gutter,
+        bottom: 0,
+        left: gutter,
+      }
+    }
+
+    return {
+      top: 0,
+      right: last ? gutter : half,
+      bottom: 0,
+      left: first ? gutter : half,
+    }
+  }
+
+  getMobilePaddingValues() {
+    const { first, last, sibling } = this.props
+    const gutter = this.getNormalizedGutterValue('%')
+    const half = gutter / 2
+
+    if (sibling === 1) {
+      return {
+        top: 0,
+        right: gutter,
+        bottom: 0,
+        left: gutter,
+      }
+    }
+
+    return {
+      top: first ? 0 : half,
+      right: gutter,
+      bottom: last ? 0 : half,
+      left: gutter,
+    }
+  }
+
+  static formatPadding(top, right, bottom, left, unit) {
+    return `${MjColumn.normalizeUnitValue(top)}${unit} ${MjColumn.normalizeUnitValue(
+      right,
+    )}${unit} ${MjColumn.normalizeUnitValue(bottom)}${unit} ${
+      MjColumn.normalizeUnitValue(left)
+    }${unit}`
+  }
+
+  getDesktopPadding() {
+    const unit = this.getDesktopUnit()
+    const { top, right, bottom, left } = this.getDesktopPaddingValues(unit)
+
+    return MjColumn.formatPadding(top, right, bottom, left, unit)
+  }
+
+  getMobilePadding() {
+    const { top, right, bottom, left } = this.getMobilePaddingValues()
+
+    return MjColumn.formatPadding(top, right, bottom, left, '%')
+  }
+
+  getMobileGutterStyles() {
+    if (!this.hasColumnGutter()) {
+      return {}
+    }
+
+    return {
+      padding: this.getMobilePadding(),
+    }
+  }
+
+  getOutlookGutterStyles() {
+    if (!this.hasColumnGutter()) {
+      return {}
+    }
+
+    const { top, right, bottom, left } = this.getDesktopPaddingValues('px')
+
+    return {
+      padding: MjColumn.formatPadding(top, right, bottom, left, 'px'),
+    }
+  }
+
+
 
   hasBorderRadius() {
     const borderRadius = this.getAttribute('border-radius')
@@ -305,7 +503,15 @@ export default class MjColumn extends BodyComponent {
   }
 
   render() {
-    let classesName = `${this.getColumnClass()} mj-outlook-group-fix`
+    const defaultClass = this.getColumnClass()
+
+    let classesName = defaultClass
+
+    if (this.hasColumnGutter()) {
+      classesName += ` ${this.getDesktopGutterClassName()}`
+    }
+
+    classesName += ' mj-outlook-group-fix'
 
     if (this.getAttribute('css-class')) {
       classesName += ` ${this.getAttribute('css-class')}`

--- a/packages/mjml-core/src/helpers/mediaQueries.js
+++ b/packages/mjml-core/src/helpers/mediaQueries.js
@@ -1,4 +1,25 @@
-import { map, isEmpty } from 'lodash'
+import { isEmpty } from 'lodash'
+
+function groupMediaQueries(mediaQueries, prefix = '') {
+  const grouped = Object.entries(mediaQueries).reduce(
+    (result, [className, mediaQuery]) => {
+      const selector = `${prefix}.${className}`
+
+      if (!result[mediaQuery]) {
+        result[mediaQuery] = []
+      }
+
+      result[mediaQuery].push(selector)
+
+      return result
+    },
+    {},
+  )
+
+  return Object.entries(grouped).map(
+    ([mediaQuery, selectors]) => `${selectors.join(', ')} ${mediaQuery}`,
+  )
+}
 
 // eslint-disable-next-line import/prefer-default-export
 export default function buildMediaQueriesTags(
@@ -12,15 +33,9 @@ export default function buildMediaQueriesTags(
 
   const { forceOWADesktop = false, printerSupport = false } = options
 
-  const baseMediaQueries = map(
-    mediaQueries,
-    (mediaQuery, className) => `.${className} ${mediaQuery}`,
-  )
-  const thunderbirdMediaQueries = map(
-    mediaQueries,
-    (mediaQuery, className) => `.moz-text-html .${className} ${mediaQuery}`,
-  )
-  const owaQueries = map(baseMediaQueries, (mq) => `[owa] ${mq}`)
+  const baseMediaQueries = groupMediaQueries(mediaQueries)
+  const thunderbirdMediaQueries = groupMediaQueries(mediaQueries, '.moz-text-html ')
+  const owaQueries = baseMediaQueries.map((mq) => `[owa] ${mq}`)
 
   return `
     <style type="text/css">

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -746,9 +746,19 @@ export default async function mjml2html(mjml, options = {}) {
   const bodyHelpers = {
     components,
     globalData,
-    addMediaQuery(className, { parsedWidth, unit }) {
-      globalData.mediaQueries[className] =
-        `{ width:${parsedWidth}${unit} !important; max-width: ${parsedWidth}${unit}; }`
+    addMediaQuery(className, { parsedWidth, unit, padding }) {
+      let rule = '{'
+
+      if (parsedWidth != null && unit != null) {
+        rule += ` width:${parsedWidth}${unit} !important; max-width: ${parsedWidth}${unit};`
+      }
+
+      if (padding) {
+        rule += ` padding: ${padding} !important;`
+      }
+
+      rule += ` }`
+      globalData.mediaQueries[className] = rule
     },
     addHeadStyle(identifier, headStyle) {
       globalData.headStyle[identifier] = headStyle

--- a/packages/mjml-group/src/index.js
+++ b/packages/mjml-group/src/index.js
@@ -43,6 +43,8 @@ export default class MjGroup extends BodyComponent {
       ...this.context,
       containerWidth,
       nonRawSiblings: children.length,
+      isInGroup: true,
+      direction: this.getAttribute('direction'),
     }
   }
 

--- a/packages/mjml-section/README.md
+++ b/packages/mjml-section/README.md
@@ -53,7 +53,7 @@ The `full-width` attribute will be used to manage the background width. Setting 
 | css-class             | string                  | class name, added to the root HTML element created                                                     |               |
 | direction             | `ltr` `rtl`             | set the display order of direct children                                                               | `ltr`         |
 | full-width            | `full-width` `false`    | make the section full-width                                                                            |               |
-| gutter                | `px` `%`                | sets an equal spacing between each column and between the end columns and the sides                    |               |
+| gutter                | `px` `%`                | sets an equal spacing between each column                                                              |               |
 | padding               | `px` `%`                | section padding, supports up to 4 parameters                                                           | `20px 0`      |
 | padding-bottom        | `px` `%`                | section bottom padding                                                                                 |               |
 | padding-left          | `px` `%`                | section left padding                                                                                   |               |

--- a/packages/mjml-section/README.md
+++ b/packages/mjml-section/README.md
@@ -53,6 +53,7 @@ The `full-width` attribute will be used to manage the background width. Setting 
 | css-class             | string                  | class name, added to the root HTML element created                                                     |               |
 | direction             | `ltr` `rtl`             | set the display order of direct children                                                               | `ltr`         |
 | full-width            | `full-width` `false`    | make the section full-width                                                                            |               |
+| gutter                | `px` `%`                | sets an equal spacing between each column and between the end columns and the sides                    |               |
 | padding               | `px` `%`                | section padding, supports up to 4 parameters                                                           | `20px 0`      |
 | padding-bottom        | `px` `%`                | section bottom padding                                                                                 |               |
 | padding-left          | `px` `%`                | section left padding                                                                                   |               |

--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -22,6 +22,7 @@ export default class MjSection extends BodyComponent {
     'border-top': 'string',
     direction: 'enum(ltr,rtl)',
     'full-width': 'enum(full-width,false,)',
+    gutter: 'unit(px,%)',
     padding: 'unit(px,%){1,4}',
     'padding-top': 'unit(px,%)',
     'padding-bottom': 'unit(px,%)',
@@ -48,6 +49,7 @@ export default class MjSection extends BodyComponent {
       ...this.context,
       containerWidth: `${box}px`,
       gap: this.getAttribute('gap'),
+      gutter: this.getAttribute('gutter'),
     }
   }
 

--- a/packages/mjml-section/src/index.js
+++ b/packages/mjml-section/src/index.js
@@ -50,6 +50,7 @@ export default class MjSection extends BodyComponent {
       containerWidth: `${box}px`,
       gap: this.getAttribute('gap'),
       gutter: this.getAttribute('gutter'),
+      direction: this.getAttribute('direction'),
     }
   }
 

--- a/packages/mjml/test/section-gutter.test.js
+++ b/packages/mjml/test/section-gutter.test.js
@@ -21,11 +21,195 @@ describe('mj-section gutter', function () {
     const { html, errors } = await mjml(input)
 
     chai.expect(errors, 'section-level gutter should not produce validation errors').to.eql([])
-    chai.expect(html).to.include('.mj-column-per-44 { width:44% !important; max-width: 44%; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-1-per-4 { padding: 0% 2% 0% 4% !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-2-per-4 { padding: 0% 4% 0% 2% !important; }')
-    chai.expect(html).to.include('class="mj-column-per-44 mj-column-gutter-2-1-per-4 mj-outlook-group-fix"')
-    chai.expect(html).to.include('class="mj-column-per-44 mj-column-gutter-2-2-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('.mj-column-per-48 { width:48% !important; max-width: 48%; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-4 { padding: 0% 2% 0% 0% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-4 { padding: 0% 0% 0% 2% !important; }')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-1-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-2-per-4 mj-outlook-group-fix"')
+  })
+
+  it('should keep rtl gutter rules isolated from ltr section gutter rules', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="4%">
+            <mj-column>
+              <mj-text>Left</mj-text>
+            </mj-column>
+            <mj-column>
+              <mj-text>Right</mj-text>
+            </mj-column>
+          </mj-section>
+          <mj-section gutter="4%">
+            <mj-group direction="rtl">
+              <mj-column>
+                <mj-text>Group Left</mj-text>
+              </mj-column>
+              <mj-column>
+                <mj-text>Group Right</mj-text>
+              </mj-column>
+            </mj-group>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'rtl gutter should not produce validation errors').to.eql([])
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-1-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-2-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-1-per-4-rtl mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-2-per-4-rtl mj-outlook-group-fix"')
+    chai.expect(html).to.include('mj-column-gutter-2-1-per-4-rtl')
+    chai.expect(html).to.include('mj-column-gutter-2-2-per-4-rtl')
+  })
+
+  it('should not emit group gutter padding media-query rules when gutter is already inline', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="4%" padding="4%">
+            <mj-group>
+              <mj-column>
+                <mj-text>Group Left</mj-text>
+              </mj-column>
+              <mj-column>
+                <mj-text>Group Right</mj-text>
+              </mj-column>
+            </mj-group>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'group gutter case should not produce validation errors').to.eql([])
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-1-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-2-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:48%;padding:0% 2% 0% 0%;"')
+    chai.expect(html).to.include('style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:48%;padding:0% 0% 0% 2%;"')
+    chai.expect(html).to.not.include('.mj-column-gutter-2-1-per-4 { padding: 0% 2% 0% 0% !important; }')
+    chai.expect(html).to.not.include('.mj-column-gutter-2-2-per-4 { padding: 0% 0% 0% 2% !important; }')
+  })
+
+  describe('advanced combinations', function () {
+    it('should support section full-width border padding and rtl direction with gutter', async function () {
+      const input = `
+        <mjml>
+          <mj-body>
+            <mj-section full-width="full-width" background-color="#f2f2f2" gutter="4%" padding="4%" border="10px solid black" direction="rtl">
+              <mj-column>
+                <mj-text>S10-C1</mj-text>
+              </mj-column>
+              <mj-column>
+                <mj-text>S10-C2</mj-text>
+              </mj-column>
+            </mj-section>
+          </mj-body>
+        </mjml>
+      `
+
+      const { html, errors } = await mjml(input)
+
+      chai.expect(errors, 'section full-width + border + rtl should not produce errors').to.eql([])
+      chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-1-per-4-rtl mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-per-48 mj-column-gutter-2-2-per-4-rtl mj-outlook-group-fix"')
+      chai.expect(html).to.include('.mj-column-gutter-2-1-per-4-rtl { padding: 0% 0% 0% 2% !important; }')
+      chai.expect(html).to.include('.mj-column-gutter-2-2-per-4-rtl { padding: 0% 2% 0% 0% !important; }')
+    })
+
+    it('should apply group direction over section direction for gutter classes', async function () {
+      const input = `
+        <mjml>
+          <mj-body>
+            <mj-section background-color="#f2f2f2" gutter="24px" padding="24px" direction="rtl">
+              <mj-group direction="ltr">
+                <mj-column>
+                  <mj-text>S13-G1-C1</mj-text>
+                </mj-column>
+                <mj-column>
+                  <mj-text>S13-G1-C2</mj-text>
+                </mj-column>
+                <mj-column>
+                  <mj-text>S13-G1-C3</mj-text>
+                </mj-column>
+              </mj-group>
+            </mj-section>
+          </mj-body>
+        </mjml>
+      `
+
+      const { html, errors } = await mjml(input)
+
+      chai.expect(errors, 'group direction override should not produce errors').to.eql([])
+      chai.expect(html).to.include('class="mj-column-per-30-434783 mj-column-gutter-3-1-per-4-347826 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-per-30-434783 mj-column-gutter-3-2-per-4-347826 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-per-30-434783 mj-column-gutter-3-3-per-4-347826 mj-outlook-group-fix"')
+      chai.expect(html).to.not.include('mj-column-gutter-3-1-per-4-347826-rtl')
+    })
+
+    it('should keep gutter calculation stable with per-column direction border padding and inner-border', async function () {
+      const input = `
+        <mjml>
+          <mj-body>
+            <mj-section background-color="#f2f2f2" gutter="4%" padding="4%">
+              <mj-column direction="rtl" border="4px solid #2f855a" padding="20px" inner-border="4px solid #276749">
+                <mj-text>A</mj-text>
+              </mj-column>
+              <mj-column direction="ltr" border="2px dashed #744210" padding="8px" inner-border="3px solid #975a16">
+                <mj-text>B</mj-text>
+              </mj-column>
+              <mj-column direction="rtl" border="1px solid #2c5282" padding="16px" inner-border="2px solid #2b6cb0">
+                <mj-text>C</mj-text>
+              </mj-column>
+            </mj-section>
+          </mj-body>
+        </mjml>
+      `
+
+      const { html, errors } = await mjml(input)
+
+      chai.expect(errors, 'column-level border/padding/inner-border with gutter should not error').to.eql([])
+      chai.expect(html).to.include('class="mj-column-per-30-666667 mj-column-gutter-3-1-per-4 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-per-30-666667 mj-column-gutter-3-2-per-4 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-per-30-666667 mj-column-gutter-3-3-per-4 mj-outlook-group-fix"')
+    })
+
+    it('should support four-column px widths with percentage gutter and balanced px rounding', async function () {
+      const input = `
+        <mjml>
+          <mj-body>
+            <mj-section background-color="#f2f2f2" gutter="2%" padding="4%">
+              <mj-column width="120px">
+                <mj-text>1</mj-text>
+              </mj-column>
+              <mj-column width="120px">
+                <mj-text>2</mj-text>
+              </mj-column>
+              <mj-column width="120px">
+                <mj-text>3</mj-text>
+              </mj-column>
+              <mj-column width="120px">
+                <mj-text>4</mj-text>
+              </mj-column>
+            </mj-section>
+          </mj-body>
+        </mjml>
+      `
+
+      const { html, errors } = await mjml(input)
+
+      chai.expect(errors, 'four-column px rounding scenario should not produce errors').to.eql([])
+      chai.expect(html).to.include('class="mj-column-px-111 mj-column-gutter-4-1-px-12 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-px-111 mj-column-gutter-4-2-px-12 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-px-111 mj-column-gutter-4-3-px-12 mj-outlook-group-fix"')
+      chai.expect(html).to.include('class="mj-column-px-111 mj-column-gutter-4-4-px-12 mj-outlook-group-fix"')
+      chai.expect(html).to.include('.mj-column-gutter-4-1-px-12 { padding: 0px 6px 0px 0px !important; }')
+      chai.expect(html).to.include('mj-column-gutter-4-2-px-12')
+      chai.expect(html).to.include('.mj-column-gutter-4-4-px-12 { padding: 0px 0px 0px 6px !important; }')
+    })
   })
 
   it('should render pixel gutter with pixel-width columns', async function () {
@@ -47,10 +231,10 @@ describe('mj-section gutter', function () {
     const { html, errors } = await mjml(input)
 
     chai.expect(errors, 'pixel gutter with px columns should not produce validation errors').to.eql([])
-    // 250px - (20px/2 + 20px/2) = 220px per column
-    chai.expect(html).to.include('.mj-column-px-220 { width:220px !important; max-width: 220px; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-1-px-20 { padding: 0px 10px 0px 20px !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-2-px-20 { padding: 0px 20px 0px 10px !important; }')
+    // 250px - (20px / 2) = 240px per column
+    chai.expect(html).to.include('.mj-column-px-240 { width:240px !important; max-width: 240px; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-px-20 { padding: 0px 10px 0px 0px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-px-20 { padding: 0px 0px 0px 10px !important; }')
   })
 
   it('should render three-column layout with pixel gutter', async function () {
@@ -76,9 +260,9 @@ describe('mj-section gutter', function () {
 
     chai.expect(errors, 'three-column pixel gutter should not produce validation errors').to.eql([])
     // 15px is converted to percentage; position-aware padding for first, middle, last
-    chai.expect(html).to.include('.mj-column-gutter-3-1-per-2-5 { padding: 0% 1.25% 0% 2.5% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-1-per-2-5 { padding: 0% 1.25% 0% 0% !important; }')
     chai.expect(html).to.include('.mj-column-gutter-3-2-per-2-5 { padding: 0% 1.25% 0% 1.25% !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-3-3-per-2-5 { padding: 0% 2.5% 0% 1.25% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-3-per-2-5 { padding: 0% 0% 0% 1.25% !important; }')
   })
 
   it('should handle mixed percentage columns with pixel gutter', async function () {
@@ -100,12 +284,12 @@ describe('mj-section gutter', function () {
     const { html, errors } = await mjml(input)
 
     chai.expect(errors, 'mixed width percentage with pixel gutter should not produce errors').to.eql([])
-    // 10px converted to percentage; 60% becomes 57.5%, 40% becomes 37.5%
-    chai.expect(html).to.include('.mj-column-per-57-5 { width:57.5% !important; max-width: 57.5%; }')
-    chai.expect(html).to.include('.mj-column-per-37-5 { width:37.5% !important; max-width: 37.5%; }')
+    // 10px converted to percentage; 60% becomes 59.166667%, 40% becomes 39.166667%
+    chai.expect(html).to.include('.mj-column-per-59-166667 { width:59.166667% !important; max-width: 59.166667%; }')
+    chai.expect(html).to.include('.mj-column-per-39-166667 { width:39.166667% !important; max-width: 39.166667%; }')
     // Padding in percentage with many decimals due to conversion
-    chai.expect(html).to.include('.mj-column-gutter-2-1-per-1-666667 { padding: 0% 0.833333% 0% 1.666667% !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-2-per-1-666667 { padding: 0% 1.666667% 0% 0.833333% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-1-666667 { padding: 0% 0.833333% 0% 0% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-1-666667 { padding: 0% 0% 0% 0.833333% !important; }')
   })
 
   it('should handle mixed pixel columns with percentage gutter', async function () {
@@ -127,12 +311,75 @@ describe('mj-section gutter', function () {
     const { html, errors } = await mjml(input)
 
     chai.expect(errors, 'mixed pixel width with percentage gutter should not produce errors').to.eql([])
-    // 3% of 600px = 18px gutter; 300px - 27px = 273px, 200px - 27px = 173px
-    chai.expect(html).to.include('.mj-column-px-273 { width:273px !important; max-width: 273px; }')
-    chai.expect(html).to.include('.mj-column-px-173 { width:173px !important; max-width: 173px; }')
+    // 3% of 600px = 18px gutter; 300px - 9px = 291px, 200px - 9px = 191px
+    chai.expect(html).to.include('.mj-column-px-291 { width:291px !important; max-width: 291px; }')
+    chai.expect(html).to.include('.mj-column-px-191 { width:191px !important; max-width: 191px; }')
     // Padding converted to px: 18px gutter
-    chai.expect(html).to.include('.mj-column-gutter-2-1-px-18 { padding: 0px 9px 0px 18px !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-2-px-18 { padding: 0px 18px 0px 9px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-px-18 { padding: 0px 9px 0px 0px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-px-18 { padding: 0px 0px 0px 9px !important; }')
+  })
+
+  it('should round decimal pixel outputs when percentage gutter is applied to px columns', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="4%" padding="4%">
+            <mj-column width="200px">
+              <mj-text>One</mj-text>
+            </mj-column>
+            <mj-column width="200px">
+              <mj-text>Two</mj-text>
+            </mj-column>
+            <mj-column width="200px">
+              <mj-text>Three</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'decimal px values should be rounded without validation errors').to.eql([])
+    chai.expect(html).to.include('.mj-column-px-185 { width:185px !important; max-width: 185px; }')
+    chai.expect(html).to.include('.mj-column-px-184 { width:184px !important; max-width: 184px; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-1-px-24 { padding: 0px 12px 0px 0px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-2-px-24 { padding: 0px 12px 0px 12px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-3-px-24 { padding: 0px 0px 0px 12px !important; }')
+    chai.expect(html).to.not.include('185.28px')
+    chai.expect(html).to.not.include('11.04px')
+    chai.expect(html).to.not.include('303.6px')
+  })
+
+  it('should pair px gutter rounding and balance px widths when rounded gutter is odd', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="3.9%" padding="4%">
+            <mj-column width="200px">
+              <mj-text>One</mj-text>
+            </mj-column>
+            <mj-column width="200px">
+              <mj-text>Two</mj-text>
+            </mj-column>
+            <mj-column width="200px">
+              <mj-text>Three</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'odd rounded px gutter should not produce validation errors').to.eql([])
+    chai.expect(html).to.include('.mj-column-gutter-3-1-px-23 { padding: 0px 12px 0px 0px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-2-px-23 { padding: 0px 12px 0px 11px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-3-px-23 { padding: 0px 0px 0px 11px !important; }')
+
+    // Width rounding is distributed across siblings so total width remains consistent
+    chai.expect(html).to.include('.mj-column-px-185 { width:185px !important; max-width: 185px; }')
+    chai.expect(html).to.include('.mj-column-px-184 { width:184px !important; max-width: 184px; }')
   })
 
   it('should handle mixed percentage gutter with default columns', async function () {
@@ -155,7 +402,7 @@ describe('mj-section gutter', function () {
 
     chai.expect(errors, 'percentage gutter with default columns should not produce errors').to.eql([])
     // Verify gutter padding classes are present
-    chai.expect(html).to.include('.mj-column-gutter-2-1-per-5 { padding: 0% 2.5% 0% 5% !important; }')
-    chai.expect(html).to.include('.mj-column-gutter-2-2-per-5 { padding: 0% 5% 0% 2.5% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-5 { padding: 0% 2.5% 0% 0% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-5 { padding: 0% 0% 0% 2.5% !important; }')
   })
 })

--- a/packages/mjml/test/section-gutter.test.js
+++ b/packages/mjml/test/section-gutter.test.js
@@ -1,0 +1,161 @@
+const chai = require('chai')
+const mjml = require('../lib')
+
+describe('mj-section gutter', function () {
+  it('should render gutter classes from mj-section and adjust desktop widths', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="4%">
+            <mj-column>
+              <mj-text>Left</mj-text>
+            </mj-column>
+            <mj-column>
+              <mj-text>Right</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'section-level gutter should not produce validation errors').to.eql([])
+    chai.expect(html).to.include('.mj-column-per-44 { width:44% !important; max-width: 44%; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-4 { padding: 0% 2% 0% 4% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-4 { padding: 0% 4% 0% 2% !important; }')
+    chai.expect(html).to.include('class="mj-column-per-44 mj-column-gutter-2-1-per-4 mj-outlook-group-fix"')
+    chai.expect(html).to.include('class="mj-column-per-44 mj-column-gutter-2-2-per-4 mj-outlook-group-fix"')
+  })
+
+  it('should render pixel gutter with pixel-width columns', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="20px">
+            <mj-column width="250px">
+              <mj-text>Left</mj-text>
+            </mj-column>
+            <mj-column width="250px">
+              <mj-text>Right</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'pixel gutter with px columns should not produce validation errors').to.eql([])
+    // 250px - (20px/2 + 20px/2) = 220px per column
+    chai.expect(html).to.include('.mj-column-px-220 { width:220px !important; max-width: 220px; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-1-px-20 { padding: 0px 10px 0px 20px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-px-20 { padding: 0px 20px 0px 10px !important; }')
+  })
+
+  it('should render three-column layout with pixel gutter', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="15px">
+            <mj-column>
+              <mj-text>One</mj-text>
+            </mj-column>
+            <mj-column>
+              <mj-text>Two</mj-text>
+            </mj-column>
+            <mj-column>
+              <mj-text>Three</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'three-column pixel gutter should not produce validation errors').to.eql([])
+    // 15px is converted to percentage; position-aware padding for first, middle, last
+    chai.expect(html).to.include('.mj-column-gutter-3-1-per-2-5 { padding: 0% 1.25% 0% 2.5% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-2-per-2-5 { padding: 0% 1.25% 0% 1.25% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-3-3-per-2-5 { padding: 0% 2.5% 0% 1.25% !important; }')
+  })
+
+  it('should handle mixed percentage columns with pixel gutter', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="10px">
+            <mj-column width="60%">
+              <mj-text>Wide</mj-text>
+            </mj-column>
+            <mj-column width="40%">
+              <mj-text>Narrow</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'mixed width percentage with pixel gutter should not produce errors').to.eql([])
+    // 10px converted to percentage; 60% becomes 57.5%, 40% becomes 37.5%
+    chai.expect(html).to.include('.mj-column-per-57-5 { width:57.5% !important; max-width: 57.5%; }')
+    chai.expect(html).to.include('.mj-column-per-37-5 { width:37.5% !important; max-width: 37.5%; }')
+    // Padding in percentage with many decimals due to conversion
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-1-666667 { padding: 0% 0.833333% 0% 1.666667% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-1-666667 { padding: 0% 1.666667% 0% 0.833333% !important; }')
+  })
+
+  it('should handle mixed pixel columns with percentage gutter', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="3%">
+            <mj-column width="300px">
+              <mj-text>Left</mj-text>
+            </mj-column>
+            <mj-column width="200px">
+              <mj-text>Right</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'mixed pixel width with percentage gutter should not produce errors').to.eql([])
+    // 3% of 600px = 18px gutter; 300px - 27px = 273px, 200px - 27px = 173px
+    chai.expect(html).to.include('.mj-column-px-273 { width:273px !important; max-width: 273px; }')
+    chai.expect(html).to.include('.mj-column-px-173 { width:173px !important; max-width: 173px; }')
+    // Padding converted to px: 18px gutter
+    chai.expect(html).to.include('.mj-column-gutter-2-1-px-18 { padding: 0px 9px 0px 18px !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-px-18 { padding: 0px 18px 0px 9px !important; }')
+  })
+
+  it('should handle mixed percentage gutter with default columns', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section gutter="5%">
+            <mj-column>
+              <mj-text>Col 1</mj-text>
+            </mj-column>
+            <mj-column>
+              <mj-text>Col 2</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+
+    const { html, errors } = await mjml(input)
+
+    chai.expect(errors, 'percentage gutter with default columns should not produce errors').to.eql([])
+    // Verify gutter padding classes are present
+    chai.expect(html).to.include('.mj-column-gutter-2-1-per-5 { padding: 0% 2.5% 0% 5% !important; }')
+    chai.expect(html).to.include('.mj-column-gutter-2-2-per-5 { padding: 0% 5% 0% 2.5% !important; }')
+  })
+})


### PR DESCRIPTION
## What's changed

- Implemented gutter spacing as a section-level attribute applied to all child columns

- Added support for mj-group-aware gutter rendering and avoid duplicate group CSS

- Supports RTL gutter padding behaviour for sections and groups

- Implemented unit-aware gutter conversion (px ↔ %)

- Added regression tests covering various mj-section gutter and mj-column width values (% and px) plus advanced gutter combinations

- Updated getting_started.md docs with gutter example and guidance

- Added attribute to docs for mj-section