### PR TITLE
Fix crash in strict validation when an mj-include is denied

### DIFF
--- a/packages/mjml-validator/src/rules/errorAttr.js
+++ b/packages/mjml-validator/src/rules/errorAttr.js
@@ -5,18 +5,20 @@ export default function errorAttr(element) {
 
   if (!errors) return null
 
-  return errors.map((error) => {
-    switch (error.type) {
-      case 'include': {
-        const { file, partialPath } = error.params
+  return errors
+    .map((error) => {
+      switch (error.type) {
+        case 'include': {
+          const { file, partialPath } = error.params
 
-        return ruleError(
-          `mj-include fails to read file : ${file} at ${partialPath}`,
-          element,
-        )
+          return ruleError(
+            `mj-include fails to read file : ${file} at ${partialPath}`,
+            element,
+          )
+        }
+        default:
+          return null
       }
-      default:
-        return null
-    }
-  })
+    })
+    .filter(Boolean)
 }

--- a/packages/mjml/test/include-path-security.test.js
+++ b/packages/mjml/test/include-path-security.test.js
@@ -68,6 +68,18 @@ describe('include path security checks (absolute, UNC, drive, null, double-encod
     chai.expect(html).to.include('<!-- mj-include denied -->')
   })
 
+  it('does not throw in strict validation mode when an include is denied', async function () {
+    const template = buildTemplate('/etc/hosts', 'type="html"')
+    const { html } = await mjml(template, {
+      filePath: rootDir,
+      actualPath: path.join(rootDir, 'template.mjml'),
+      ignoreIncludes: false,
+      validationLevel: 'strict',
+      minify: false,
+    })
+    chai.expect(html).to.include('<!-- mj-include denied -->')
+  })
+
   it('denies UNC-like path', async function () {
     const template = buildTemplate('//server/share/file.mjml')
     const { html } = await mjml(template, {


### PR DESCRIPTION
## Bug

`mjml2html(template, { validationLevel: 'strict', ignoreIncludes: false })` throws

```
TypeError: Cannot read properties of null (reading 'formattedMessage')
```

whenever the template contains an `mj-include` whose path is blocked by the include security checks (absolute path, drive letter, UNC path, null byte, or outside the allowed roots).

## Root cause

When an include is denied, the parser attaches an error of type `include-denied` to the generated `mj-raw` node. The `errorAttr` validator rule only handles the `include` case and returns `null` for every other type:

```js
return errors.map((error) => {
  switch (error.type) {
    case 'include': { ... }
    default:
      return null   // include-denied falls through here
  }
})
```

`MJMLValidator` spreads that array into its error list (`errors.push(...ruleError)`), so a `null` enters the list. In `strict` mode `mjml-core` then runs `errors.map((e) => e.formattedMessage)`, dereferencing the `null`.

## Solution

`errorAttr` now filters falsy entries out of its result, so "no error for this type" (the intended meaning of `default: return null`) no longer poisons the error list. A denied include renders as before (the `<!-- mj-include denied -->` placeholder) instead of crashing.

Closes #3114

## Testing

Added a case to `packages/mjml/test/include-path-security.test.js` that renders a denied absolute-path include with `validationLevel: 'strict'` and asserts it does not throw. Before the change this test fails with the exact `TypeError` above; after it passes. Suites: `mjml` 102 passing, `mjml-core` 20 passing.
