### PR TITLE
perf(mjml-parser-xml): replace O(n²) line-number lookup with binary search

### DIFF
--- a/packages/mjml-parser-xml/src/index.js
+++ b/packages/mjml-parser-xml/src/index.js
@@ -1,6 +1,6 @@
 import { Parser } from 'htmlparser2'
 
-import { isObject, findLastIndex, find } from 'lodash'
+import { isObject, find } from 'lodash'
 import { filter, map, flow } from 'lodash/fp'
 import path from 'path'
 import fs from 'fs'
@@ -20,6 +20,30 @@ const indexesForNewLine = (xml) => {
   }
 
   return indexes
+}
+
+// lineIndexes is sorted ascending (built by scanning the document once, in order), so the
+// last index <= startIndex can be found with a binary search instead of lodash's findLastIndex,
+// which scans linearly. Since this runs once per opened tag/comment, the linear scan makes
+// parsing effectively O(n^2) for documents with many small repeated elements (e.g. templates
+// rendering long, per-item loops), while this is O(log n) per tag.
+const findLastIndexOfLineStart = (sortedIndexes, startIndex) => {
+  let low = 0
+  let high = sortedIndexes.length - 1
+  let result = -1
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+
+    if (sortedIndexes[mid] <= startIndex) {
+      result = mid
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+
+  return result
 }
 
 const isSelfClosing = (indexes, parser) =>
@@ -340,7 +364,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
         }
 
         const line =
-          findLastIndex(lineIndexes, (i) => i <= parser.startIndex) + 1
+          findLastIndexOfLineStart(lineIndexes, parser.startIndex) + 1
 
         if (name === 'mj-include') {
           if (ignoreIncludes || !isNode) return
@@ -425,7 +449,7 @@ export default function MJMLParser(xml, options = {}, includedIn = []) {
 
         if (cur && keepComments) {
           cur.children.push({
-            line: findLastIndex(lineIndexes, (i) => i <= parser.startIndex) + 1,
+            line: findLastIndexOfLineStart(lineIndexes, parser.startIndex) + 1,
             tagName: 'mj-raw',
             content: `<!--${data}-->`,
             includedIn,


### PR DESCRIPTION
## What

`MJMLParser` computes each opened tag's/comment's source line number (used only for error messages) via lodash's `findLastIndex(lineIndexes, i => i <= parser.startIndex)` — a linear scan over the document's newline-index array, run once per tag/comment. `lineIndexes` is already built in ascending order, so this replaces the linear scan with a binary search that returns the mathematically identical result.

## Why

Both the tag count and the line count of a document scale together with its size, so this linear-scan-per-tag makes parsing effectively **O(n²)** for documents with many small, repeated elements — e.g. an invoice/report template rendering a long per-line-item loop. We hit this in production rendering a statement PDF with ~1,600 repeated line items, where `mjml2html()` alone took over a minute.

I benchmarked against the built `mjml` package (this repo, `master`, no other changes) with a synthetic document of repeated `mj-section`/`mj-column`/`mj-text` blocks (a stand-in for a line-item row), doubling roughly in size at each step:

| N (repeated rows) | before | after |
|---:|---:|---:|
| 50 | 24ms | 25ms |
| 200 | 78ms | 61ms |
| 500 | 227ms | 132ms |
| 800 | 425ms | 203ms |
| 1200 | 865ms | 332ms |
| 1578 | 1463ms | 398ms |
| 3000 | 4385ms | 718ms |

Before: 24ms → 4385ms for a 60x increase in row count (≈183x slower — clearly superlinear). After: 25ms → 718ms for the same 60x increase (≈29x — roughly linear, matching the O(n log n) expectation for n tags each doing an O(log n) lookup).

## Correctness

Line numbers are unchanged — only the algorithm used to compute them changed. All existing `mjml-parser-xml` tests pass (including tests that assert exact `line` values via deep-equal against fixtures), as do the `mjml-core` and `mjml` package test suites, all unmodified.

```
$ yarn test   # packages/mjml-parser-xml
  9 passing
```

## Scope

Only `packages/mjml-parser-xml/src/index.js` changed — no behavior, API, or output difference, purely an algorithmic complexity fix for the internal line-tracking used in error/warning messages.