### PR TITLE
docs: note that templating tags break with mj-html-attributes

### DIFF
--- a/doc/ending-tags.md
+++ b/doc/ending-tags.md
@@ -6,7 +6,7 @@ These components can contain both text and HTML content, which will remain unpro
 
 Since the content is not processed, this means that any text won't be escaped, so if you use characters that are used to define html tags in your text, like `<` or `>`, you should use the encoded characters `&lt;` and `&lt;`.
 
-There can also be issues if you use the `minify` option, `mj-html-attributes` or an inline `mj-style`, because these require the HTML to be re-parsed internally.
+There can also be issues if you use the `minify` option, `mj-html-attributes` or an inline `mj-style`, because these require the HTML to be re-parsed internally. In particular, `mj-html-attributes` can rewrite template tags that resemble HTML/XML (for example EJS `<%= value %>`).
 
 If you're just using the `minify` option, and need to use the `< >` characters, e.g for a templating language, you can also avoid this problem by wrapping the troublesome content between two `<!-- htmlmin:ignore -->` tags.
 

--- a/packages/mjml-head-html-attributes/README.md
+++ b/packages/mjml-head-html-attributes/README.md
@@ -33,4 +33,6 @@ To use this component, you will likely have to look at the generated HTML to see
 
 You can use multiple `mj-selector` tags inside a `mj-html-attributes` tag, and multiple `mj-html-attribute` tags inside a `mj-selector` tag.
 
+Note: `mj-html-attributes` re-parses the generated HTML internally. Template tags that look like HTML or XML (for example EJS `<%= value %>`) can be altered or broken during that pass. Prefer running your templating engine after MJML rendering, or avoid combining those tags with `mj-html-attributes`.
+
 <p class="cta-container"><a class="cta" href="https://mjml.io/try-it-live/components/head-html-attributes">Try it live</a></p>

--- a/packages/mjml-head-html-attributes/README.md
+++ b/packages/mjml-head-html-attributes/README.md
@@ -33,6 +33,9 @@ To use this component, you will likely have to look at the generated HTML to see
 
 You can use multiple `mj-selector` tags inside a `mj-html-attributes` tag, and multiple `mj-html-attribute` tags inside a `mj-selector` tag.
 
-Note: `mj-html-attributes` re-parses the generated HTML internally. Template tags that look like HTML or XML (for example EJS `<%= value %>`) can be altered or broken during that pass. Prefer running your templating engine after MJML rendering, or avoid combining those tags with `mj-html-attributes`.
+<div class="alert alert-caution" role="alert">
+  <p>Caution</p>
+  <p><code>mj-html-attributes</code> re-parses the generated HTML internally. Template tags that look like HTML or XML (for example EJS <code>&lt;%= value %&gt;</code>) can be altered or broken during that pass. Prefer running your templating engine after MJML rendering, or avoid combining those tags with <code>mj-html-attributes</code>.</p>
+</div>
 
 <p class="cta-container"><a class="cta" href="https://mjml.io/try-it-live/components/head-html-attributes">Try it live</a></p>


### PR DESCRIPTION
## Summary
- Documents that `mj-html-attributes` re-parses HTML and can rewrite template tags that look like HTML/XML (for example EJS `<%= %>`).
- Adds a short clarification on the ending-tags page as well.

Fixes #2744

## Test plan
- [ ] Confirm the new note reads clearly on the mj-html-attributes docs page
- [ ] Confirm ending-tags still makes sense with the extra sentence