### PR TITLE
fix(mjml-core): don't turn <br> into <br></br> when an mj-selector is present

### DIFF
--- a/packages/mjml-core/package.json
+++ b/packages/mjml-core/package.json
@@ -27,6 +27,7 @@
     "cssnano": "^7.1.2",
     "cssnano-preset-lite": "^4.0.4",
     "detect-node": "^2.0.4",
+    "dom-serializer": "^2.0.0",
     "htmlnano": "^3.3.1",
     "js-beautify": "^1.15.4",
     "juice": "^11.0.0",

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -12,6 +12,7 @@ import {
 } from 'lodash'
 import juice from 'juice'
 import { load } from 'cheerio'
+import render from 'dom-serializer'
 import minifier from 'htmlnano'
 import MJMLParser from 'mjml-parser-xml'
 import MJMLValidator, {
@@ -839,7 +840,18 @@ export default async function mjml2html(mjml, options = {}) {
       })
     })
 
-    content = $.root().html()
+    /*
+     * The document has to be parsed as XML, but it is HTML, so it is rendered
+     * back with the HTML serializer. Rendering it as XML would emit void
+     * elements as `<br/>` or, when the parser gave them children, as
+     * `<br></br>`, which means the mere presence of an mj-selector would
+     * change how they are written.
+     */
+    content = render($.root()[0], {
+      xmlMode: false,
+      decodeEntities: false, // same reason as above
+      emptyAttrs: true, // keeps `alt=""` instead of writing it `alt`
+    })
   }
 
   content = skeleton({

--- a/packages/mjml/test/html-attributes.test.js
+++ b/packages/mjml/test/html-attributes.test.js
@@ -107,7 +107,74 @@ describe('html-attributes', function () {
 </mjml>
 `
 
-    const bodies = {
+    const VOID_ELEMENTS =
+      'area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr'
+
+    /*
+     * Every void element in the output. Conditional comments are taken out
+     * first, because what is inside them is never parsed and so keeps the form
+     * the component wrote it in.
+     */
+    const voidTags = (html) =>
+      html
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .match(new RegExp(`</?(?:${VOID_ELEMENTS})(?![\\w-])[^>]*>`, 'gi')) ||
+      []
+
+    /*
+     * A template compiled with a selector is parsed and rendered again, one
+     * compiled without a selector is not, so the two outputs are not byte
+     * identical even when they mean the same thing. These two rules absorb the
+     * differences that carry no meaning, so the comparison only fails on a real
+     * one. The form of the tag itself is not left to the comparison, since
+     * `<br/>` reads as `<br>` under the same rule. It is pinned separately, by
+     * the closing tag and self closing assertions below.
+     */
+    const normalize = (tags) =>
+      tags.map((tag) =>
+        tag
+          // `checked=""` and `checked` are the same attribute.
+          .replace(/\s([\w-]+)=""/g, ' $1')
+          // `<img />` and `<img>` are the same element.
+          .replace(/\s*\/>$/, '>'),
+      )
+
+    const expectParity = async (text, name) => {
+      const [without, withSelector] = await Promise.all([
+        mjml(template(false, text)),
+        mjml(template(true, text)),
+      ])
+      const tags = voidTags(withSelector.html)
+
+      // Without this the comparison below would also pass on an output that
+      // lost the element altogether.
+      chai
+        .expect(
+          tags.filter((tag) => tag.startsWith(`<${name}`)).length,
+          `<${name}> is in the output`,
+        )
+        .to.be.above(0)
+
+      chai
+        .expect(
+          tags.filter((tag) => tag.startsWith('</')),
+          `No closing tag on <${name}>`,
+        )
+        .to.deep.equal([])
+
+      chai
+        .expect(
+          tags.filter((tag) => tag.endsWith('/>')),
+          `No self closing slash on <${name}>`,
+        )
+        .to.deep.equal([])
+
+      chai
+        .expect(normalize(tags), 'Same void elements as without a selector')
+        .to.deep.equal(normalize(voidTags(without.html)))
+    }
+
+    const positions = {
       'inside a <p>': `
           <p>
             Hello World!<br>
@@ -121,35 +188,42 @@ describe('html-attributes', function () {
         `,
     }
 
-    Object.entries(bodies).forEach(([position, text]) => {
+    Object.entries(positions).forEach(([position, text]) => {
       it(`emits the same <br> with and without an mj-selector, ${position}`, async function () {
-        const [without, withSelector] = await Promise.all([
-          mjml(template(false, text)),
-          mjml(template(true, text)),
-        ])
-
-        const brs = (html) => html.match(/<br[^>]*>|<\/br\s*>/g) || []
-
-        chai
-          .expect(brs(withSelector.html), 'No closing tag on <br>')
-          .to.deep.equal(['<br>'])
-
-        chai
-          .expect(brs(withSelector.html), 'Same <br> as without a selector')
-          .to.deep.equal(brs(without.html))
+        await expectParity(text, 'br')
       })
     })
 
-    it('does not add a closing tag to images', async function () {
-      const text = `
-          <p>Hello<br><img src="https://via.placeholder.com/150x30" /></p>
-        `
-      const { html } = await mjml(template(true, text))
+    const elements = {
+      br: '<p>Hello<br>World!</p>',
+      hr: '<p>Above</p><hr><p>Below</p>',
+      input: '<input type="checkbox" checked>',
+      img: '<img src="https://via.placeholder.com/150x30" alt="">',
+    }
 
-      chai.expect(html, 'No closing tag on <img>').to.not.include('</img>')
+    Object.entries(elements).forEach(([name, text]) => {
+      it(`emits the same <${name}> with and without an mj-selector`, async function () {
+        await expectParity(text, name)
+      })
+    })
+
+    it('leaves void elements inside a conditional comment alone', async function () {
+      const comment = '<!--[if mso]><br><![endif]-->'
+      const [without, withSelector] = await Promise.all([
+        mjml(template(false, comment)),
+        mjml(template(true, comment)),
+      ])
+
       chai
-        .expect(html, 'Image src left untouched')
-        .to.include('src="https://via.placeholder.com/150x30"')
+        .expect(withSelector.html, 'Conditional comment kept as authored')
+        .to.include(comment)
+
+      chai
+        .expect(
+          withSelector.html.includes(comment),
+          'Same as without a selector',
+        )
+        .to.equal(without.html.includes(comment))
     })
   })
 })

--- a/packages/mjml/test/html-attributes.test.js
+++ b/packages/mjml/test/html-attributes.test.js
@@ -81,4 +81,75 @@ describe('html-attributes', function () {
       .expect(sortBy(indexes), 'Mj-raws kept same positions')
       .to.deep.eql(indexes)
   })
+
+  // https://github.com/mjmlio/mjml/issues/3112
+  describe('void elements', function () {
+    // The path matches nothing in the body on purpose: the bug was triggered
+    // by the mere presence of an mj-selector, wherever it points.
+    const head = `
+  <mj-head>
+    <mj-html-attributes>
+      <mj-selector path=".unrelated div">
+        <mj-html-attribute name="data-id">42</mj-html-attribute>
+      </mj-selector>
+    </mj-html-attributes>
+  </mj-head>`
+
+    const template = (withSelector, text) => `
+<mjml>${withSelector ? head : ''}
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text css-class="custom">${text}</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`
+
+    const bodies = {
+      'inside a <p>': `
+          <p>
+            Hello World!<br>
+          </p>
+        `,
+      'outside any <p>': `
+          Hello World!<br>
+        `,
+      'followed by another element': `
+          <p>Hello<br><span>World!</span></p>
+        `,
+    }
+
+    Object.entries(bodies).forEach(([position, text]) => {
+      it(`emits the same <br> with and without an mj-selector, ${position}`, async function () {
+        const [without, withSelector] = await Promise.all([
+          mjml(template(false, text)),
+          mjml(template(true, text)),
+        ])
+
+        const brs = (html) => html.match(/<br[^>]*>|<\/br\s*>/g) || []
+
+        chai
+          .expect(brs(withSelector.html), 'No closing tag on <br>')
+          .to.deep.equal(['<br>'])
+
+        chai
+          .expect(brs(withSelector.html), 'Same <br> as without a selector')
+          .to.deep.equal(brs(without.html))
+      })
+    })
+
+    it('does not add a closing tag to images', async function () {
+      const text = `
+          <p>Hello<br><img src="https://via.placeholder.com/150x30" /></p>
+        `
+      const { html } = await mjml(template(true, text))
+
+      chai.expect(html, 'No closing tag on <img>').to.not.include('</img>')
+      chai
+        .expect(html, 'Image src left untouched')
+        .to.include('src="https://via.placeholder.com/150x30"')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #3112

### Problem

`<br>` compiles to three different things depending on whether an `mj-selector` exists anywhere in the document, even when its `path` targets something unrelated:

| authored | no `mj-selector` | with an `mj-selector` |
| --- | --- | --- |
| `<br>` inside a `<p>` | `<br>` | `<br></br>` |
| `<br>` as the last child | `<br>` | `<br/>` |
| `<br />` | `<br />` | `<br/>` |

`<br></br>` is not just cosmetically wrong. Clients recover from it inconsistently and some render a doubled line break.

### Cause

`mj-selector` is what populates `globalData.htmlAttributes`, and a non empty `htmlAttributes` round trips the whole document through cheerio in `packages/mjml-core/src/index.js`:

```js
if (!isEmpty(globalData.htmlAttributes)) {
  const $ = load(content, {
    xmlMode: true, // otherwise it may move contents that aren't in any tag
    decodeEntities: false, // won't escape special characters
  })
  // ...apply attributes...
  content = $.root().html()
}
```

XML mode has no notion of HTML void elements, so `<br>` is parsed as an element that requires a closing tag. Whatever follows it inside its parent becomes its children and it is serialized back as `<br>...</br>`; with no children it is serialized as `<br/>`. When no selector is present this block is skipped and the markup is never reparsed, which is why the selector's `path` makes no difference: the reparse rewrites the element, not the selector.

### Approach

`xmlMode: true` is deliberate and the comment on that line explains why, so parsing is left exactly as it is. Only the rendering changes.

Asking cheerio for the HTML rendering does not work, because it picks its renderer from the parsing options. Passing `xmlMode: false` to `$.html()` makes it fall through to parse5, which escapes text and so defeats `decodeEntities: false`, and it does not fix the void elements either since the nodes carry no HTML namespace. Checked locally, `<p>Hi<br>There</p><div>{ if a < 5 }</div>` comes back as `<p>Hi<br>There</br></p><div>{ if a &lt; 5 }</div>`.

`dom-serializer` is the renderer cheerio already uses underneath, and it takes its options directly, so the block renders the document itself instead:

```js
content = render($.root()[0], {
  xmlMode: false,
  decodeEntities: false,
  emptyAttrs: true,
})
```

`xmlMode: false` is what makes the serializer treat void elements as void, `decodeEntities: false` keeps the templating syntax intact for the same reason it is set on the parser, and `emptyAttrs: true` keeps `alt=""` written in full rather than as a bare `alt`.

### Result

Compiled output with a selector present, before and after. This is the whole diff on a template exercising `mj-image`, `mj-divider`, `mj-text`, `mj-social`, `mj-navbar`, `mj-button`, `mj-table`, `mj-accordion`, `mj-carousel` and `mj-spacer`:

```diff
- <p>Hello<br>World!</br></p>
+ <p>Hello<br>World!</p>

- Trailing<br/>
+ Trailing<br>

- <img alt="x" src="..." width="550" height="auto"/>
+ <img alt="x" src="..." width="550" height="auto">

- <input class="mj-accordion-checkbox" type="checkbox" style="display:none;"/>
+ <input class="mj-accordion-checkbox" type="checkbox" style="display:none;">
```

No structural, attribute or entity changes, and conditional comments are untouched.

The first two lines are the bug. The last two are the same change applied to the other void elements, which the serializer treats alike.

Exact parity with the no-selector path is not reachable, because the round trip loses whether the author wrote `<br>` or `<br />`. This block already normalizes that today, writing both as `<br/>`, so what changes here is which form it normalizes to.

### Not covered

The `<%= %>` mangling documented in #3118 / #2744 is a separate, parse level problem (the XML parser reads `<%=` as a tag name). Confirmed locally that this change neither fixes it nor makes it worse.

### Testing

`yarn build && yarn test && yarn lint`. Lint clean. Regression tests added in `packages/mjml/test/html-attributes.test.js`, which compiles each case below with and without the `mj-selector` and asserts the `<br>` output is identical, plus that no closing tag is added to `<img>`. All three fail before this change and pass after.

MJML used to test locally, from the three cases in the issue. Each was compiled twice, once as written and once with the `mj-head` block removed:

**Case 1 and 2, `<br>` inside a `<p>`**

```xml
<mjml>
  <mj-head>
    <mj-html-attributes>
      <mj-selector path=".unrelated div">
        <mj-html-attribute name="data-id">42</mj-html-attribute>
      </mj-selector>
    </mj-html-attributes>
  </mj-head>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-text css-class="custom">
          <p>
            Hello World!<br>
          </p>
        </mj-text>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

Before: `<p> Hello World!<br>\n </br></p>`. After: `<p> Hello World!<br>\n </p>`, identical to the no-selector output.

**Case 3, `<br>` outside any `<p>`**

```xml
<mjml>
  <mj-head>
    <mj-html-attributes>
      <mj-selector path=".unrelated div">
        <mj-html-attribute name="data-id">42</mj-html-attribute>
      </mj-selector>
    </mj-html-attributes>
  </mj-head>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-text css-class="custom">
          Hello World!<br>
        </mj-text>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

Before: `Hello World!<br/>`. After: `Hello World!<br>`, identical to the no-selector output.

**A `<br>` followed by a sibling element**

```xml
<mjml>
  <mj-head>
    <mj-html-attributes>
      <mj-selector path=".unrelated div">
        <mj-html-attribute name="data-id">42</mj-html-attribute>
      </mj-selector>
    </mj-html-attributes>
  </mj-head>
  <mj-body>
    <mj-section>
      <mj-column>
        <mj-text css-class="custom">
          <p>Hello<br><span>World!</span></p>
        </mj-text>
      </mj-column>
    </mj-section>
  </mj-body>
</mjml>
```

Before: `<p>Hello<br><span>World!</span></br></p>`. After: `<p>Hello<br><span>World!</span></p>`.

I do not have a Litmus or Email on Acid account, so there are no client screenshots here. The change replaces invalid markup with the canonical HTML form rather than adding a styling attribute, so the compiled output above is the evidence. Happy to work with someone who has access if you want client captures before merging.
