### PR TITLE
Typo in About

### DIFF
--- a/doc/create.md
+++ b/doc/create.md
@@ -2,4 +2,4 @@
 
 One of the great advantages of MJML is that it's component-based. Components abstract complex patterns and can easily be reused. In addition to the standard library of components, it is also possible to create your own components!
 
-We have published [a step-by-step guide](https://medium.com/mjml-making-responsive-email-easy/tutorial-creating-your-own-component-with-mjml-4-1c0e84e97b36) that explains how to create a custom components with MJML. It will introduce you to the [boilerplate repo](https://github.com/mjmlio/mjml-component-boilerplate) hosted on Github, which provides a fast way of getting started with developing your own components.
+We have published [a step-by-step guide](https://medium.com/mjml-making-responsive email-easy/tutorial-creating-your-own-component-with-mjml-4-1c0e84e97b36) that explains how to create a custom components with MJML. It will introduce you to the [boilerplate repo](https://github.com/mjmlio/mjml-component-boilerplate) hosted on Github, which provides a fast way of getting started with developing your own components.


### PR DESCRIPTION
Fixes #3125

This corrects `responsive-email` to `responsive email` in `doc/create.md`, as reported in #3125.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #3125