### PR TITLE
feat: container-border-radius and mj-social update

### DIFF
--- a/packages/mjml-accordion/README.md
+++ b/packages/mjml-accordion/README.md
@@ -57,7 +57,8 @@ Readers can interact by clicking on the tabs to reveal the content, providing a 
 | attribute                  | accepts                 | description                                        | default value                     |
 | -------------------------- | ----------------------- | -------------------------------------------------- | --------------------------------- |
 | border                     | string                  | CSS border format                                  | `2px solid black`                 |
-| container-background-color | CSS color formats       | background-color of the cell                       |                                   |
+| container-background-color | CSS color formats       | background color of the container                  |                                   |
+| container-border-radius    | string                  | border radius of the container                     |                                   |
 | css-class                  | string                  | class name, added to the root HTML element created |                                   |
 | font-family                | string                  | font                                               | `Ubuntu, sans-serif`              |
 | icon-align                 | `top` `middle` `bottom` | icon alignment                                     |                                   |
@@ -80,10 +81,11 @@ Readers can interact by clicking on the tabs to reveal the content, providing a 
 
 ###### Dark-mode
 
-| attribute                | accepts | description                                | default value |
-| ------------------------ | ------- | ------------------------------------------ | ------------- |
-| icon-unwrapped-url--dark | string  | dark-mode icon when accordion is unwrapped |               |
-| icon-wrapped-url--dark   | string  | dark-mode icon when accordion is wrapped   |               |
+| attribute                  | accepts           | description                                    | default value |
+| -------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| container-background-color | CSS color formats | background color of the container in dark mode |               |
+| icon-unwrapped-url--dark   | string            | dark-mode icon when accordion is unwrapped     |               |
+| icon-wrapped-url--dark     | string            | dark-mode icon when accordion is wrapped       |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-accordion/src/Accordion.js
+++ b/packages/mjml-accordion/src/Accordion.js
@@ -16,6 +16,7 @@ export default class MjAccordion extends BodyComponent {
     'aria-roledescription': 'string',
     border: 'string',
     'border-color--dark': 'color',
+    'container-border-radius': 'string',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
     'font-family': 'string',

--- a/packages/mjml-button/README.md
+++ b/packages/mjml-button/README.md
@@ -47,7 +47,8 @@ Displays a customizable button.
 | border-right               | string                             | CSS border format                                     |                      |
 | border-top                 | string                             | CSS border format                                     |                      |
 | color                      | CSS color formats                  | text color                                            | `#ffffff`            |
-| container-background-color | CSS color formats                  | button container background color                     |                      |
+| container-background-color | CSS color formats                  | background color of the container                     |                      |
+| container-border-radius    | string                             | border radius of the container                        |                      |
 | css-class                  | string                             | class name, added to the root HTML element created    |                      |
 | font-family                | string                             | font name                                             | `Ubuntu, sans-serif` |
 | font-size                  | `px` `rem`                         | text size                                             | `16px`               |
@@ -89,7 +90,7 @@ Displays a customizable button.
 | border-right-color--dark         | CSS color formats | button right border color in dark mode         |               |
 | border-top-color--dark           | CSS color formats | button top border color in dark mode           |               |
 | color--dark                      | CSS color formats | button text color in dark mode                 |               |
-| container-background-color--dark | CSS color formats | button container background color in dark mode |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-button/src/index.js
+++ b/packages/mjml-button/src/index.js
@@ -44,6 +44,7 @@ export default class MjButton extends BodyComponent {
     'color--dark': 'color',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'font-family': 'string',
     'font-size': 'unit(px,rem)',
     'font-size--responsive': 'unit(px,rem)',

--- a/packages/mjml-carousel/README.md
+++ b/packages/mjml-carousel/README.md
@@ -30,7 +30,8 @@ Displays a gallery of images or "carousel". Readers can interact by hovering and
 | aria-label                 | string                         | adds an `aria-label` attribute to the slide container           |                                   |
 | aria-roledescription       | string                         | adds an `aria-roledescription` attribute to the slide container |                                   |
 | border-radius              | string                         | border radius                                                   | `6px`                             |
-| container-background-color | CSS color formats              | column background color                                         |                                   |
+| container-background-color | CSS color formats              | background color of the container                               |                                   |
+| container-border-radius    | string                         | border radius of the container                                  |                                   |
 | css-class                  | string                         | class name, added to the root HTML element created              |                                   |
 | icon-width                 | `px` `%`                       | width of the icons on left and right of the main image          | `44px`                            |
 | left-icon                  | string                         | icon on the left of the main image                              | `https://i.imgur.com/xTh3hln.png` |
@@ -57,7 +58,7 @@ Displays a gallery of images or "carousel". Readers can interact by hovering and
 
 | attribute                        | accepts           | description                                         | default value |
 | -------------------------------- | ----------------- | --------------------------------------------------- | ------------- |
-| container-background-color--dark | CSS color formats | column background color in dark mode                |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode      |               |
 | left-icon--dark                  | string            | dark-mode icon on the left of the main image        |               |
 | right-icon--dark                 | string            | dark-mode icon on the right of the main image       |               |
 | tb-border-color--dark            | CSS color formats | border color of the thumbnails in dark mode         |               |

--- a/packages/mjml-carousel/src/Carousel.js
+++ b/packages/mjml-carousel/src/Carousel.js
@@ -25,6 +25,7 @@ export default class MjCarousel extends BodyComponent {
     'border-radius': 'string',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'icon-width': 'unit(px,%)',
     'icon-width--responsive': 'unit(px,%)',
     'left-icon': 'string',

--- a/packages/mjml-column/src/index.js
+++ b/packages/mjml-column/src/index.js
@@ -738,6 +738,7 @@ export default class MjColumn extends BodyComponent {
                     background: component.getAttribute(
                       'container-background-color',
                     ),
+                    'border-radius': component.getAttribute('container-border-radius'),
                     'font-size': '0px',
                     padding: component.getAttribute('padding'),
                     'padding-top': component.getAttribute('padding-top'),

--- a/packages/mjml-core/tests/responsiveComponentsRegression.test.js
+++ b/packages/mjml-core/tests/responsiveComponentsRegression.test.js
@@ -56,7 +56,8 @@ describe('responsive regression coverage', () => {
       </mjml>
     `)
 
-    const tableMatch = html.match(/<table[^>]*style="[^"]*background:orange[^"]*"[^>]*class="([^"]*mj-responsive-\d+[^"]*)"/)
+    // background/border-radius moved to icon <td>; table now carries only the responsive class
+    const tableMatch = html.match(/<table[^>]*role="none"[^>]*class="([^"]*mj-responsive-\d+[^"]*)"/)
     assert.ok(tableMatch, 'expected responsive class on icon table')
 
     const iconClass = tableMatch[1].split(/\s+/).find((className) => /^mj-responsive-\d+$/.test(className))
@@ -65,7 +66,7 @@ describe('responsive regression coverage', () => {
     assert.ok(html.includes(`.${iconClass},`))
     assert.ok(html.includes(`.${iconClass} td`))
     assert.ok(html.includes(`.${iconClass} img`))
-    assert.ok(/<td style="padding:20px;font-size:0;height:60px;">/.test(html))
+    assert.ok(/<td style="padding:20px;font-size:0;height:60px;background:orange;border-radius:3px;">/.test(html))
   })
 
   it('mj-table emits stack CSS in a dedicated style tag after responsive/scroll styles', async () => {

--- a/packages/mjml-divider/README.md
+++ b/packages/mjml-divider/README.md
@@ -23,7 +23,8 @@ Displays a horizontal divider that can be customized like a HTML border.
 | border-color               | CSS color formats       | divider color                                          | `#000000`     |
 | border-style               | string                  | CSS values, e.g. `dashed` `dotted` `solid`             | `solid`       |
 | border-width               | `px`                    | divider's border width                                 | `4px`         |
-| container-background-color | CSS color formats       | inner element background color                         |               |
+| container-background-color | CSS color formats       | background color of the container                      |               |
+| container-border-radius    | string                  | border radius of the container                         |               |
 | css-class                  | string                  | class name, added to the root HTML element created     |               |
 | padding                    | `px` `%`                | divider padding, supports up to 4 parameters           | `10px 25px`   |
 | padding-bottom             | `px` `%`                | divider bottom padding                                 |               |
@@ -38,10 +39,10 @@ Displays a horizontal divider that can be customized like a HTML border.
 
 ###### Dark-mode
 
-| attribute                        | accepts           | description                                 | default value |
-| -------------------------------- | ----------------- | ------------------------------------------- | ------------- |
-| border-color--dark               | CSS color formats | divider color in dark mode                  |               |
-| container-background-color--dark | CSS color formats | inner element background color in dark mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| border-color--dark               | CSS color formats | divider color in dark mode                     |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-divider/src/index.js
+++ b/packages/mjml-divider/src/index.js
@@ -29,6 +29,7 @@ export default class MjDivider extends BodyComponent {
     'border-width': 'unit(px)',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     padding: 'unit(px,%){1,4}',
     'padding--responsive': 'unit(px,%){1,4}',
     'padding-bottom': 'unit(px,%)',

--- a/packages/mjml-image/README.md
+++ b/packages/mjml-image/README.md
@@ -29,7 +29,8 @@ Note that if no width is provided, the image will use the parent column width.
 | border-radius              | string                  | border radius                                                                   |                       |
 | border-right               | string                  | CSS border format                                                               |                       |
 | border-top                 | string                  | CSS border format                                                               |                       |
-| container-background-color | CSS color formats       | inner element background color                                                  |                       |
+| container-background-color | CSS color formats       | background color of the container                                               |                       |
+| container-border-radius    | string                  | border radius of the container                                                  |                       |
 | css-class                  | string                  | class name, added to the root HTML element created                              |                       |
 | fluid-on-mobile            | boolean                 | if `true`, will be full width on mobile even if `width` is set                  |                       |
 | font-size                  | `px` `rem`              | size of the alt text when image is not rendered                                 | `16px`                |
@@ -65,7 +66,7 @@ Note that if no width is provided, the image will use the parent column width.
 | border-left-color--dark          | CSS color formats | image left border color in dark mode                                       |               |
 | border-right-color--dark         | CSS color formats | image right border color in dark mode                                      |               |
 | border-top-color--dark           | CSS color formats | image top border color in dark mode                                        |               |
-| container-background-color--dark | CSS color formats | inner element background color in dark mode                                |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode                             |               |
 | src--dark                        | string            | image used for dark mode (set `support-dark-mode="true"` in `<mjml>` tag). |               |
 
 <div class="alert alert-note" role="alert">

--- a/packages/mjml-image/src/index.js
+++ b/packages/mjml-image/src/index.js
@@ -49,6 +49,7 @@ export default class MjImage extends BodyComponent {
     'border-top-color--dark': 'color',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'fluid-on-mobile': 'boolean',
     'font-size': 'unit(px,rem)',
     'font-size--responsive': 'unit(px,rem)',

--- a/packages/mjml-navbar/README.md
+++ b/packages/mjml-navbar/README.md
@@ -50,35 +50,37 @@ Displays a navigation menu with an optional `hamburger` mode for mobile devices.
 
 #### Attributes
 
-| attribute            | accepts                       | description                                                                                                             | default value        |
-| -------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| align                | `left`<br>`center`<br>`right` | align content                                                                                                           | `center`             |
-| aria-label           | string                        | adds an `aria-label` attribute to the navbar container                                                                  |                      |
-| aria-roledescription | string                        | adds an `aria-roledescription` attribute to the navbar container                                                        |                      |
-| base-url             | string                        | base URL for child components                                                                                           | `null`               |
-| css-class            | string                        | class name, added to the root HTML element created                                                                      |                      |
-| hamburger            | string                        | activate the hamburger navigation on mobile if the value is hamburger                                                   | `null`               |
-| ico-align            | `left`<br>`center`<br>`right` | hamburger icon alignment<br> (`hamburger="hamburger"` required)                                                         | `center`             |
-| ico-close            | string                        | char code for a custom close icon, e.g. ASCII code decimal<br> (`hamburger="hamburger"` required)                       | `&#8855;`            |
-| ico-color            | CSS color formats             | hamburger icon color<br> (`hamburger="hamburger"` required)                                                             | `#000000`            |
-| ico-font-family      | string                        | hamburger icon font<br> (`hamburger="hamburger"` required)                                                              | `Ubuntu, sans-serif` |
-| ico-font-size        | `px` `%`                      | hamburger icon size<br> (`hamburger="hamburger"` required)                                                              | `30px`               |
-| ico-line-height      | `px` `%`                      | hamburger icon line height<br> (`hamburger="hamburger"` required)                                                       | `30px`               |
-| ico-open             | string                        | char code for a custom open icon, e.g. ASCII code decimal<br> (`hamburger="hamburger"` required)                        | `&#9776;`            |
-| ico-padding          | `px` `%`                      | hamburger icon padding, supports up to 4 parameters<br> (`hamburger="hamburger"` required)                              | `10px`               |
-| ico-padding-bottom   | `px` `%`                      | hamburger icon bottom padding<br> (`hamburger="hamburger"` required)                                                    |                      |
-| ico-padding-left     | `px` `%`                      | hamburger icon left padding<br> (`hamburger="hamburger"` required)                                                      |                      |
-| ico-padding-right    | `px` `%`                      | hamburger icon right padding<br> (`hamburger="hamburger"` required)                                                     |                      |
-| ico-padding-top      | `px` `%`                      | hamburger icon top padding<br> (`hamburger="hamburger"` required)                                                       |                      |
-| ico-text-decoration  | string                        | hamburger icon text decoration e.g. `none` `underline` `overline` `line-through`<br> (`hamburger="hamburger"` required) |                      |
-| ico-text-transform   | string                        | hamburger icon text transformation `none` `capitalize` `uppercase` `lowercase`<br> (`hamburger="hamburger"` required)   | `uppercase`          |
-| padding              | `px` `%`                      | navbar padding, supports up to 4 parameters                                                                             |                      |
-| padding-bottom       | `px` `%`                      | navbar bottom padding                                                                                                   |                      |
-| padding-left         | `px` `%`                      | navbar left padding                                                                                                     |                      |
-| padding-right        | `px` `%`                      | navbar right padding                                                                                                    |                      |
-| padding-top          | `px` `%`                      | navbar top padding                                                                                                      |                      |
-| responsive-mode      | `stack`                       | stack links on single lines below the breakpoint                                                                        |                      |
-| role                 | string                        | adds a `role` attribute to the navbar container                                                                         |                      |
+| attribute                  | accepts                       | description                                                                                                             | default value        |
+| -------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| align                      | `left`<br>`center`<br>`right` | align content                                                                                                           | `center`             |
+| aria-label                 | string                        | adds an `aria-label` attribute to the navbar container                                                                  |                      |
+| aria-roledescription       | string                        | adds an `aria-roledescription` attribute to the navbar container                                                        |                      |
+| base-url                   | string                        | base URL for child components                                                                                           | `null`               |
+| container-background-color | CSS color formats             | background color of the container                                                                                       |                      |
+| container-border-radius    | string                        | border radius of the container                                                                                          |                      |
+| css-class                  | string                        | class name, added to the root HTML element created                                                                      |                      |
+| hamburger                  | string                        | activate the hamburger navigation on mobile if the value is hamburger                                                   | `null`               |
+| ico-align                  | `left`<br>`center`<br>`right` | hamburger icon alignment<br> (`hamburger="hamburger"` required)                                                         | `center`             |
+| ico-close                  | string                        | char code for a custom close icon, e.g. ASCII code decimal<br> (`hamburger="hamburger"` required)                       | `&#8855;`            |
+| ico-color                  | CSS color formats             | hamburger icon color<br> (`hamburger="hamburger"` required)                                                             | `#000000`            |
+| ico-font-family            | string                        | hamburger icon font<br> (`hamburger="hamburger"` required)                                                              | `Ubuntu, sans-serif` |
+| ico-font-size              | `px` `%`                      | hamburger icon size<br> (`hamburger="hamburger"` required)                                                              | `30px`               |
+| ico-line-height            | `px` `%`                      | hamburger icon line height<br> (`hamburger="hamburger"` required)                                                       | `30px`               |
+| ico-open                   | string                        | char code for a custom open icon, e.g. ASCII code decimal<br> (`hamburger="hamburger"` required)                        | `&#9776;`            |
+| ico-padding                | `px` `%`                      | hamburger icon padding, supports up to 4 parameters<br> (`hamburger="hamburger"` required)                              | `10px`               |
+| ico-padding-bottom         | `px` `%`                      | hamburger icon bottom padding<br> (`hamburger="hamburger"` required)                                                    |                      |
+| ico-padding-left           | `px` `%`                      | hamburger icon left padding<br> (`hamburger="hamburger"` required)                                                      |                      |
+| ico-padding-right          | `px` `%`                      | hamburger icon right padding<br> (`hamburger="hamburger"` required)                                                     |                      |
+| ico-padding-top            | `px` `%`                      | hamburger icon top padding<br> (`hamburger="hamburger"` required)                                                       |                      |
+| ico-text-decoration        | string                        | hamburger icon text decoration e.g. `none` `underline` `overline` `line-through`<br> (`hamburger="hamburger"` required) |                      |
+| ico-text-transform         | string                        | hamburger icon text transformation `none` `capitalize` `uppercase` `lowercase`<br> (`hamburger="hamburger"` required)   | `uppercase`          |
+| padding                    | `px` `%`                      | navbar padding, supports up to 4 parameters                                                                             |                      |
+| padding-bottom             | `px` `%`                      | navbar bottom padding                                                                                                   |                      |
+| padding-left               | `px` `%`                      | navbar left padding                                                                                                     |                      |
+| padding-right              | `px` `%`                      | navbar right padding                                                                                                    |                      |
+| padding-top                | `px` `%`                      | navbar top padding                                                                                                      |                      |
+| responsive-mode            | `stack`                       | stack links on single lines below the breakpoint                                                                        |                      |
+| role                       | string                        | adds a `role` attribute to the navbar container                                                                         |                      |
 
 <p class="cta-container"><a class="cta" href="https://mjml.io/try-it-live/components/navbar">Try it live</a></p>
 
@@ -86,9 +88,10 @@ Displays a navigation menu with an optional `hamburger` mode for mobile devices.
 
 ###### Dark-mode
 
-| attribute       | accepts           | description                       | default value |
-| --------------- | ----------------- | --------------------------------- | ------------- |
-| ico-color--dark | CSS color formats | hamburger icon color in dark mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode |               |
+| ico-color--dark                  | CSS color formats | hamburger icon color in dark mode              |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-navbar/src/Navbar.js
+++ b/packages/mjml-navbar/src/Navbar.js
@@ -22,6 +22,9 @@ export default class MjNavbar extends BodyComponent {
     'aria-label': 'string',
     'aria-roledescription': 'string',
     'base-url': 'string',
+    'container-background-color': 'color',
+    'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     hamburger: 'string',
     'ico-align': 'enum(left,center,right)',
     'ico-close': 'string',
@@ -81,6 +84,14 @@ export default class MjNavbar extends BodyComponent {
     this.darkClasses = {}
 
     const globalData = this.context && this.context.globalData
+
+    const darkContainerBg = this.attributes['container-background-color--dark']
+    if (darkContainerBg) {
+      this.darkClasses.container = registerDarkModeRule(globalData, {
+        cssProperty: 'background-color',
+        cssValue: darkContainerBg,
+      })
+    }
 
     const darkIcoColor = this.getAttribute('ico-color--dark')
     if (darkIcoColor) {
@@ -181,8 +192,9 @@ ${selectors} { display: block !important }
   getAttribute(name) {
     if (name === 'css-class') {
       const base = this.attributes['css-class']
+      const containerDarkClass = this.getDarkClasses().container
       const containerResponsiveClass = this.getResponsiveClasses().container
-      return [base, containerResponsiveClass].filter(Boolean).join(' ') || undefined
+      return [base, containerDarkClass, containerResponsiveClass].filter(Boolean).join(' ') || undefined
     }
 
     return this.attributes[name]

--- a/packages/mjml-social/README.md
+++ b/packages/mjml-social/README.md
@@ -38,31 +38,33 @@ Displays calls-to-action for various social networks with their associated logo.
 
 #### Attributes
 
-| attribute                  | accepts                 | description                                        | default value        |
-| -------------------------- | ----------------------- | -------------------------------------------------- | -------------------- |
-| align                      | `left` `right` `center` | align content                                      | `center`             |
-| border                     | string                  | icon border, applied to each `mj-social-element`   |                      |
-| border-radius              | `px` `%`                | border radius                                      | `3px`                |
-| color                      | CSS color formats       | text color                                         | `#333333`            |
-| container-background-color | CSS color formats       | inner element background color                     |                      |
-| css-class                  | string                  | class name, added to the root HTML element created |                      |
-| font-family                | string                  | font name                                          | `Ubuntu, sans-serif` |
-| font-size                  | `px` `rem`              | font size                                          | `16px`               |
-| font-style                 | string                  | font style                                         | normal               |
-| font-weight                | string                  | font weight                                        | normal               |
-| icon-height                | `px` `%`                | icon height, overrides `icon-size`                 | icon-size            |
-| icon-padding               | `px` `%`                | padding around the icons                           |                      |
-| icon-size                  | `px` `%`                | icon size (width and height)                       | `20px`               |
-| inner-padding              | `px` `%`                | social network surrounding padding                 | `null`               |
-| line-height                | `px` `%` `em` `rem`     | space between lines                                | `150%`               |
-| mode                       | `horizontal` `vertical` | direction of social elements                       | `horizontal`         |
-| padding                    | `px` `%`                | social padding, supports up to 4 parameters        | `10px 25px`          |
-| padding-bottom             | `px` `%`                | bottom padding                                     |                      |
-| padding-left               | `px` `%`                | left padding                                       |                      |
-| padding-right              | `px` `%`                | right padding                                      |                      |
-| padding-top                | `px` `%`                | top padding                                        |                      |
-| text-decoration            | string                  | CSS values, e.g. `underline` `overline` `none`     | `none`               |
-| text-padding               | `px` `%`                | padding around the text                            |                      |
+| attribute                  | accepts                 | description                                                                   | default value        |
+| -------------------------- | ----------------------- | ----------------------------------------------------------------------------- | -------------------- |
+| align                      | `left` `right` `center` | align content                                                                 | `center`             |
+| border                     | string                  | icon border, applied to each `mj-social-element`                              |                      |
+| border-radius              | `px` `%`                | border radius                                                                 | `3px`                |
+| color                      | CSS color formats       | text color                                                                    | `#333333`            |
+| container-background-color | CSS color formats       | background color of the container                                             |                      |
+| container-border-radius    | string                  | border radius of the container                                                |                      |
+| css-class                  | string                  | class name, added to the root HTML element created                            |                      |
+| font-family                | string                  | font name                                                                     | `Ubuntu, sans-serif` |
+| font-size                  | `px` `rem`              | font size                                                                     | `16px`               |
+| font-style                 | string                  | font style                                                                    | normal               |
+| font-weight                | string                  | font weight                                                                   | normal               |
+| icon-height                | `px` `%`                | icon height, overrides `icon-size`                                            | icon-size            |
+| icon-padding               | `px` `%`                | padding around the icons                                                      |                      |
+| icon-size                  | `px` `%`                | icon size (width and height)                                                  | `20px`               |
+| gutter                     | `px`                    | gutter around the whole element (icon and text). Excludes the outermost sides | `null`               |
+| line-height                | `px` `%` `em` `rem`     | space between lines                                                           | `150%`               |
+| mode                       | `horizontal` `vertical` | direction of social elements                                                  | `horizontal`         |
+| padding                    | `px` `%`                | social padding, supports up to 4 parameters                                   | `10px 25px`          |
+| padding-bottom             | `px` `%`                | bottom padding                                                                |                      |
+| padding-left               | `px` `%`                | left padding                                                                  |                      |
+| padding-right              | `px` `%`                | right padding                                                                 |                      |
+| padding-top                | `px` `%`                | top padding                                                                   |                      |
+| responsive-mode            | `stack`                 | stack mj-social-element instances below the breakpoint                        |                      |
+| text-decoration            | string                  | CSS values, e.g. `underline` `overline` `none`                                | `none`               |
+| text-spacing               | `px`                    | spacing between the text and the icon                                         |                      |
 
 <p class="cta-container"><a class="cta" href="https://mjml.io/try-it-live/components/social">Try it live</a></p>
 
@@ -70,10 +72,10 @@ Displays calls-to-action for various social networks with their associated logo.
 
 ###### Dark-mode
 
-| attribute                        | accepts           | description                             | default value |
-| -------------------------------- | ----------------- | --------------------------------------- | ------------- |
-| color--dark                      | CSS color formats | text color in dark mode                 |               |
-| container-background-color--dark | CSS color formats | container background color in dark mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| color--dark                      | CSS color formats | text color in dark mode                        |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>
@@ -89,14 +91,14 @@ Displays calls-to-action for various social networks with their associated logo.
 | icon-height--responsive    | `px` `%`                | icon height, overrides `icon-size` (applied to all child elements) |               |
 | icon-padding--responsive   | `px` `%`                | padding around the icons (applied to all child elements)           |               |
 | icon-size--responsive      | `px` `%`                | icon size (width and height) (applied to all child elements)       |               |
-| inner-padding--responsive  | `px` `%`                | social network surrounding padding (applied to all child elements) |               |
+| gutter--responsive         | `px`                    | gutter around the whole element (applied to all child elements)    |               |
 | line-height--responsive    | `px` `%` `em` `rem`     | space between lines (applied to all child elements)                |               |
 | padding--responsive        | `px` `%`                | social padding, supports up to 4 parameters                        |               |
 | padding-bottom--responsive | `px` `%`                | bottom padding                                                     |               |
 | padding-left--responsive   | `px` `%`                | left padding                                                       |               |
 | padding-right--responsive  | `px` `%`                | right padding                                                      |               |
 | padding-top--responsive    | `px` `%`                | top padding                                                        |               |
-| text-padding--responsive   | `px` `%`                | padding around the text (applied to all child elements)            |               |
+| text-spacing--responsive   | `px`                    | padding around the text (applied to all child elements)            |               |
 
 #### mj-social-element
 
@@ -127,16 +129,10 @@ Note that default icons are transparent, which allows `background-color` to actu
 | font-weight             | string                  | font weight                                                                     |                                        |
 | href                    | string                  | button redirection, in URL format                                               |                                        |
 | icon-height             | `px` `%`                | icon height, overrides icon-size                                                | `icon-size`                            |
-| icon-padding            | `px` `%`                | padding around the icon                                                         |                                        |
 | icon-position           | `left` `right`          | sets the side of the icon                                                       |                                        |
 | icon-size               | `px` `%`                | icon size (width and height)                                                    |                                        |
 | line-height             | `px` `%` `em` `rem`     | space between lines                                                             | `150%`                                 |
 | name                    | string                  | social network name, see supported list below                                   |                                        |
-| padding                 | `px` `%`                | social element padding, supports up to 4 parameters                             | `4px`                                  |
-| padding-bottom          | `px` `%`                | bottom padding                                                                  |                                        |
-| padding-left            | `px` `%`                | left padding                                                                    |                                        |
-| padding-right           | `px` `%`                | right padding                                                                   |                                        |
-| padding-top             | `px` `%`                | top padding                                                                     |                                        |
 | rel                     | string                  | specify the rel attribute for the link                                          |                                        |
 | sizes                   | string                  | set icon width based on query                                                   |                                        |
 | src                     | string                  | image source, in URL format                                                     | Each social `name` has its own default |
@@ -144,7 +140,6 @@ Note that default icons are transparent, which allows `background-color` to actu
 | support-dark-mode-image | `outlook`               | enables dark-mode image support for New Outlook, Outlook App and Outlook.com    |                                        |
 | target                  | string                  | link target                                                                     |                                        |
 | text-decoration         | string                  | CSS values, e.g. `underline` `overline` `none`                                  | `none`                                 |
-| text-padding            | `px` `%`                | padding around the text                                                         | `4px 4px 4px 0`                        |
 | title                   | string                  | image title attribute                                                           |                                        |
 | vertical-align          | `top` `middle` `bottom` | vertically align elements                                                       |                                        |
 
@@ -170,15 +165,8 @@ Note that default icons are transparent, which allows `background-color` to actu
 | align--responsive          | `left` `center` `right` | align content                                              |               |
 | font-size--responsive      | `px` `rem`              | font size                                                  |               |
 | icon-height--responsive    | `px` `%`                | icon height, overrides icon-size                           |               |
-| icon-padding--responsive   | `px` `%`                | padding around the icon                                    |               |
 | icon-size--responsive      | `px` `%`                | icon size; also overrides the icon image `width` attribute |               |
 | line-height--responsive    | `px` `%` `em` `rem`     | space between lines                                        |               |
-| padding--responsive        | `px` `%`                | social element padding, supports up to 4 parameters        |               |
-| padding-bottom--responsive | `px` `%`                | bottom padding                                             |               |
-| padding-left--responsive   | `px` `%`                | left padding                                               |               |
-| padding-right--responsive  | `px` `%`                | right padding                                              |               |
-| padding-top--responsive    | `px` `%`                | top padding                                                |               |
-| text-padding--responsive   | `px` `%`                | padding around the text                                    |               |
 
 Supported networks with a share url:
 

--- a/packages/mjml-social/src/Social.js
+++ b/packages/mjml-social/src/Social.js
@@ -23,19 +23,20 @@ export default class MjSocial extends BodyComponent {
     'color--dark': 'color',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'font-family': 'string',
     'font-size': 'unit(px,rem)',
     'font-size--responsive': 'unit(px,rem)',
     'font-style': 'string',
     'font-weight': 'string',
+    'gutter': 'unit(px){1,4}',
+    'gutter--responsive': 'unit(px){1,4}',
     'icon-size': 'unit(px,%)',
     'icon-size--responsive': 'unit(px,%)',
     'icon-height': 'unit(px,%)',
     'icon-height--responsive': 'unit(px,%)',
     'icon-padding': 'unit(px,%){1,4}',
     'icon-padding--responsive': 'unit(px,%){1,4}',
-    'inner-padding': 'unit(px,%){1,4}',
-    'inner-padding--responsive': 'unit(px,%){1,4}',
     'line-height': 'unit(px,%,em,rem)',
     'line-height--responsive': 'unit(px,%,em,rem)',
     mode: 'enum(horizontal,vertical)',
@@ -49,10 +50,11 @@ export default class MjSocial extends BodyComponent {
     'padding-right--responsive': 'unit(px,%)',
     'padding-top': 'unit(px,%)',
     'padding-top--responsive': 'unit(px,%)',
+    'responsive-mode': 'enum(stack)',
     'table-layout': 'enum(auto,fixed)',
     'text-decoration': 'string',
-    'text-padding': 'unit(px,%){1,4}',
-    'text-padding--responsive': 'unit(px,%){1,4}',
+    'text-spacing': 'unit(px){1,4}',
+    'text-spacing--responsive': 'unit(px){1,4}',
     'vertical-align': 'enum(top,bottom,middle)',
   }
 
@@ -63,11 +65,12 @@ export default class MjSocial extends BodyComponent {
     'font-family': 'Ubuntu, sans-serif',
     'font-size': '16px',
     'icon-size': '20px',
-    'inner-padding': null,
+    'gutter': null,
     'line-height': '150%',
     mode: 'horizontal',
     padding: '10px 25px',
     'text-decoration': 'none',
+    'text-spacing': '4px 4px 4px 0',
   }
 
   darkContainerClass = undefined
@@ -130,8 +133,22 @@ export default class MjSocial extends BodyComponent {
   }
 
   componentHeadStyle = () => {
-    emitDarkModeHeadStyle(this.context && this.context.globalData)
-    emitResponsiveHeadStyle(this.context && this.context.globalData)
+    const globalData = this.context && this.context.globalData
+    emitDarkModeHeadStyle(globalData)
+    emitResponsiveHeadStyle(globalData)
+
+    if (globalData && globalData.hasSocialStack && !globalData.socialStackStyleEmitted) {
+      globalData.socialStackStyleEmitted = true
+      globalData.headRaw.push(`<style>
+  @media only screen and (max-width:479px) {
+    .mj-social-stack {
+      display: table !important;
+      float: none !important;
+    }
+  }
+</style>`)
+    }
+
     return ''
   }
 
@@ -146,14 +163,14 @@ export default class MjSocial extends BodyComponent {
 
   getSocialElementAttributes() {
     const base = {}
-    if (this.getAttribute('inner-padding')) {
-      base.padding = this.getAttribute('inner-padding')
+    if (this.getAttribute('gutter')) {
+      base.padding = this.getAttribute('gutter')
     }
-    if (this.attributes['inner-padding--responsive']) {
-      base['padding--responsive'] = this.attributes['inner-padding--responsive']
+    if (this.attributes['gutter--responsive']) {
+      base['padding--responsive'] = this.attributes['gutter--responsive']
     }
-
     return [
+      'align--responsive',
       'border',
       'border-radius',
       'color',
@@ -161,20 +178,20 @@ export default class MjSocial extends BodyComponent {
       'font-family',
       'font-size',
       'font-size--responsive',
-      'font-weight',
       'font-style',
-      'icon-size',
-      'icon-size--responsive',
+      'font-weight',
       'icon-height',
       'icon-height--responsive',
       'icon-padding',
       'icon-padding--responsive',
-      'text-padding',
-      'text-padding--responsive',
+      'icon-size',
+      'icon-size--responsive',
       'line-height',
       'line-height--responsive',
-      'align--responsive',
+      'mode',
       'text-decoration',
+      'text-spacing',
+      'text-spacing--responsive',
     ]
       .filter((e) => !isNil(this.getAttribute(e)))
       .reduce((res, attr) => {
@@ -185,6 +202,12 @@ export default class MjSocial extends BodyComponent {
 
   renderHorizontal() {
     const { children } = this.props
+    const isStack = this.getAttribute('responsive-mode') === 'stack'
+    const globalData = this.context && this.context.globalData
+
+    if (isStack && globalData) {
+      globalData.hasSocialStack = true
+    }
 
     return `
       ${msoConditionalTag(`<table
@@ -218,6 +241,7 @@ export default class MjSocial extends BodyComponent {
                     float: 'none',
                     display: 'inline-table',
                   },
+                  class: isStack ? 'mj-social-stack' : null,
                 })}
               >
                 ${component.render()}

--- a/packages/mjml-social/src/SocialElement.js
+++ b/packages/mjml-social/src/SocialElement.js
@@ -8,7 +8,6 @@ import {
   emitResponsiveHeadStyle,
   buildResponsiveDeclarations,
   registerResponsiveRuleGroup,
-  registerResponsivePaddingGroup,
 } from 'mjml-core/lib/helpers/responsiveMode'
 import {
   emitOutlookDarkModeHeadRaw,
@@ -110,6 +109,28 @@ each(defaultSocialNetworks, (val, key) => {
   }
 })
 
+// Expand CSS padding shorthand to [top, right, bottom, left] per CSS rules
+function expandPadding(padding) {
+  const parts = String(padding).trim().split(/\s+/)
+  const t = parts[0]
+  const r = parts[1] !== undefined ? parts[1] : t
+  const b = parts[2] !== undefined ? parts[2] : t
+  const l = parts[3] !== undefined ? parts[3] : r
+  return [t, r, b, l]
+}
+
+function applyGutterEdgeZero(padding, mode, first, last) {
+  if (!padding) return padding
+  if (!first && !last) return padding
+  const [t, r, b, l] = expandPadding(padding)
+  return [
+    mode === 'vertical' && first ? '0' : t,
+    mode === 'horizontal' && last ? '0' : r,
+    mode === 'vertical' && last ? '0' : b,
+    mode === 'horizontal' && first ? '0' : l,
+  ].join(' ')
+}
+
 export default class MjSocialElement extends BodyComponent {
   static componentName = 'mj-social-element'
 
@@ -133,24 +154,12 @@ export default class MjSocialElement extends BodyComponent {
     href: 'string',
     'icon-height': 'unit(px,%)',
     'icon-height--responsive': 'unit(px,%)',
-    'icon-padding': 'unit(px,%){1,4}',
-    'icon-padding--responsive': 'unit(px,%){1,4}',
     'icon-position': 'enum(left,right)',
     'icon-size': 'unit(px,%)',
     'icon-size--responsive': 'unit(px,%)',
     'line-height': 'unit(px,%,em,rem)',
     'line-height--responsive': 'unit(px,%,em,rem)',
     name: 'string',
-    padding: 'unit(px,%){1,4}',
-    'padding--responsive': 'unit(px,%){1,4}',
-    'padding-bottom': 'unit(px,%)',
-    'padding-bottom--responsive': 'unit(px,%)',
-    'padding-left': 'unit(px,%)',
-    'padding-left--responsive': 'unit(px,%)',
-    'padding-right': 'unit(px,%)',
-    'padding-right--responsive': 'unit(px,%)',
-    'padding-top': 'unit(px,%)',
-    'padding-top--responsive': 'unit(px,%)',
     rel: 'string',
     src: 'string',
     'src--dark': 'string',
@@ -160,8 +169,6 @@ export default class MjSocialElement extends BodyComponent {
     target: 'string',
     title: 'string',
     'text-decoration': 'string',
-    'text-padding': 'unit(px,%){1,4}',
-    'text-padding--responsive': 'unit(px,%){1,4}',
     'vertical-align': 'enum(top,middle,bottom)',
   }
 
@@ -174,8 +181,6 @@ export default class MjSocialElement extends BodyComponent {
     'font-family': 'Ubuntu, sans-serif',
     'font-size': '16px',
     'line-height': '150%',
-    padding: '4px',
-    'text-padding': '4px 4px 4px 0',
     'text-decoration': 'none',
   }
 
@@ -246,7 +251,16 @@ export default class MjSocialElement extends BodyComponent {
 
     const globalData = this.context && this.context.globalData
 
-    this.responsiveClasses.td = registerResponsivePaddingGroup(globalData, this.attributes)
+    this.responsiveClasses.td = registerResponsiveRuleGroup(globalData, {
+      cssDeclarations: buildResponsiveDeclarations([
+        ['padding', applyGutterEdgeZero(
+          this.attributes['padding--responsive'],
+          this.getAttribute('mode'),
+          this.props.first,
+          this.props.last,
+        )],
+      ]),
+    })
 
     const iconHeightResponsive =
       this.attributes['icon-height--responsive'] || this.attributes['icon-size--responsive']
@@ -272,7 +286,7 @@ export default class MjSocialElement extends BodyComponent {
 
     this.responsiveClasses.tdText = registerResponsiveRuleGroup(globalData, {
       cssDeclarations: buildResponsiveDeclarations([
-        ['padding', this.attributes['text-padding--responsive']],
+        ['padding-left', this.attributes['text-spacing--responsive']],
         ['text-align', this.attributes['align--responsive']],
       ]),
     })
@@ -296,22 +310,21 @@ export default class MjSocialElement extends BodyComponent {
 
     return {
       td: {
-        padding: this.getAttribute('padding'),
-        'padding-top': this.getAttribute('padding-top'),
-        'padding-right': this.getAttribute('padding-right'),
-        'padding-bottom': this.getAttribute('padding-bottom'),
-        'padding-left': this.getAttribute('padding-left'),
+        padding: applyGutterEdgeZero(
+          this.getAttribute('padding'),
+          this.getAttribute('mode'),
+          this.props.first,
+          this.props.last,
+        ),
         'vertical-align': this.getAttribute('vertical-align'),
       },
-      table: {
-        background: backgroundColor,
-        'border-radius': this.getAttribute('border-radius'),
-        height: iconHeight || iconSize,
-      },
+      table: {},
       icon: {
         padding: this.getAttribute('icon-padding'),
         'font-size': '0',
         height: iconHeight || iconSize,
+        background: backgroundColor,
+        'border-radius': this.getAttribute('border-radius'),
       },
       img: {
         border: this.getAttribute('border'),
@@ -319,7 +332,7 @@ export default class MjSocialElement extends BodyComponent {
         display: 'block',
       },
       tdText: {
-        padding: this.getAttribute('text-padding'),
+        'padding-left': this.getAttribute('text-spacing'),
         'text-align': this.getAttribute('align'),
       },
       text: {
@@ -509,24 +522,10 @@ export default class MjSocialElement extends BodyComponent {
 
     const content = darkImg || picture || img
 
-    const makeIcon = () => `<td ${this.htmlAttributes({ style: 'td', class: tdResponsiveClass || undefined })}>
-          <table
-            ${this.htmlAttributes({
-              border: '0',
-              cellpadding: '0',
-              cellspacing: '0',
-              role: 'none',
-              style: 'table',
-              class: [darkClasses.background, iconResponsiveClass]
-                .filter(Boolean)
-                .join(' ') || null,
-            })}
-          >
-            <tr>
-              <td ${this.htmlAttributes({
-                style: 'icon',
-                class: undefined,
-              })}>
+    const iconTd = `<td ${this.htmlAttributes({
+          style: 'icon',
+          class: darkClasses.background || undefined,
+        })}>
                 ${
                   hasLink && !darkImg
                     ? `<a ${this.htmlAttributes({
@@ -538,15 +537,10 @@ export default class MjSocialElement extends BodyComponent {
                 }
                   ${content}
                 ${hasLink && !darkImg ? `</a>` : ''}
-              </td>
-            </tr>
-          </table>
-        </td>`
+              </td>`
 
-    const makeContent = () => `
-        ${
-          this.getContent()
-            ? `<td ${this.htmlAttributes({ style: 'tdText', class: tdTextResponsiveClass || undefined })}>
+    const textTd = this.getContent()
+      ? `<td ${this.htmlAttributes({ style: 'tdText', class: tdTextResponsiveClass || undefined })}>
             ${
               hasLink
                 ? `<a
@@ -566,19 +560,35 @@ export default class MjSocialElement extends BodyComponent {
               ${this.getContent()}
             ${hasLink ? `</a>` : '</span>'}
           </td>`
-            : ''
-        }
-      `
+      : ''
 
-    const renderLeft = () => `${makeIcon()} ${makeContent()}`
-    const renderRight = () => `${makeContent()} ${makeIcon()}`
+    const innerRow = iconPosition === 'left'
+      ? `${iconTd} ${textTd}`
+      : `${textTd} ${iconTd}`
 
     return `<tr
         ${this.htmlAttributes({
           class: this.getAttribute('css-class'),
         })}
       >
-        ${iconPosition === 'left' ? renderLeft() : renderRight()}
+        <td ${this.htmlAttributes({
+          style: 'td',
+          class: tdResponsiveClass || undefined,
+        })}>
+          <table
+            ${this.htmlAttributes({
+              border: '0',
+              cellpadding: '0',
+              cellspacing: '0',
+              role: 'none',
+              class: iconResponsiveClass || null,
+            })}
+          >
+            <tr>
+              ${innerRow}
+            </tr>
+          </table>
+        </td>
       </tr>`
   }
 }

--- a/packages/mjml-spacer/README.md
+++ b/packages/mjml-spacer/README.md
@@ -21,7 +21,8 @@ Displays a blank space, that can be used to separate content.
 | attribute                  | accepts           | description                                           | default value |
 | -------------------------- | ----------------- | ----------------------------------------------------- | ------------- |
 | aria-hidden                | string            | adds an `aria-hidden` attribute to the spacer element | `true`        |
-| container-background-color | CSS color formats | inner element background color                        |               |
+| container-background-color | CSS color formats | background color of the container                     |               |
+| container-border-radius    | string            | border radius of the container                        |               |
 | css-class                  | string            | class name, added to the root HTML element created    |               |
 | height                     | `px` `%`          | spacer height                                         | `0px`         |
 | padding                    | `px` `%`          | spacer padding, supports up to 4 parameters           |               |
@@ -36,9 +37,9 @@ Displays a blank space, that can be used to separate content.
 
 ###### Dark-mode
 
-| attribute                        | accepts           | description                       | default value |
-| -------------------------------- | ----------------- | --------------------------------- | ------------- |
-| container-background-color--dark | CSS color formats | the background color in dark-mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| container-background-color--dark | CSS color formats | background color of the container in dark-mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-spacer/src/index.js
+++ b/packages/mjml-spacer/src/index.js
@@ -22,6 +22,7 @@ export default class MjSpacer extends BodyComponent {
     'border-top': 'string',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     height: 'unit(px,%)',
     'height--responsive': 'unit(px,%)',
     padding: 'unit(px,%){1,4}',

--- a/packages/mjml-table/README.md
+++ b/packages/mjml-table/README.md
@@ -47,7 +47,8 @@ Display a data table. It only accepts plain HTML.
 | cellpadding                | integer                            | space between cells                                   | `0`                  |
 | cellspacing                | integer                            | space between cell and border                         | `0`                  |
 | color                      | CSS color formats                  | text header & footer color                            | `#000000`            |
-| container-background-color | CSS color formats                  | inner element background color                        |                      |
+| container-background-color | CSS color formats                  | background color of the container                     |                      |
+| container-border-radius    | string                             | border radius of the container                        |                      |
 | css-class                  | string                             | class name, added to the root HTML element created    |                      |
 | font-family                | string                             | font name                                             | `Ubuntu, sans-serif` |
 | font-size                  | `px` `rem`                         | font size                                             | `16px`               |
@@ -94,11 +95,11 @@ Display a data table. It only accepts plain HTML.
 
 ###### Dark-mode
 
-| attribute                        | accepts           | description                                 | default value |
-| -------------------------------- | ----------------- | ------------------------------------------- | ------------- |
-| border-color--dark               | CSS color formats | table border color in dark mode             |               |
-| color--dark                      | CSS color formats | text header & footer color in dark mode     |               |
-| container-background-color--dark | CSS color formats | inner element background color in dark mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| border-color--dark               | CSS color formats | table border color in dark mode                |               |
+| color--dark                      | CSS color formats | text header & footer color in dark mode        |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark-mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-table/src/index.js
+++ b/packages/mjml-table/src/index.js
@@ -38,6 +38,7 @@ export default class MjTable extends BodyComponent {
     'color--dark': 'color',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'font-family': 'string',
     'font-size': 'unit(px,rem)',
     'font-size--responsive': 'unit(px,rem)',

--- a/packages/mjml-text/README.md
+++ b/packages/mjml-text/README.md
@@ -30,7 +30,8 @@ Displays text which can be styled.
 | -------------------------- | --------------------------------- | ------------------------------------------------------------ | -------------------- |
 | align                      | `left` `right` `center` `justify` | text-alignment                                               | `left`               |
 | color                      | CSS color formats                 | text color                                                   | `#000000`            |
-| container-background-color | CSS color formats                 | inner element background color                               |                      |
+| container-background-color | CSS color formats                 | background color of the container                            |                      |
+| container-border-radius    | string                            | border radius of the container                               |                      |
 | css-class                  | string                            | class name, added to the root HTML element created           |                      |
 | font-family                | string                            | font                                                         | `Ubuntu, sans-serif` |
 | font-size                  | `px` `rem`                        | text size                                                    | `16px`               |
@@ -59,10 +60,10 @@ Displays text which can be styled.
 
 ###### Dark-mode
 
-| attribute                        | accepts           | description                       | default value |
-| -------------------------------- | ----------------- | --------------------------------- | ------------- |
-| color--dark                      | CSS color formats | the text color in dark-mode       |               |
-| container-background-color--dark | CSS color formats | the background color in dark-mode |               |
+| attribute                        | accepts           | description                                    | default value |
+| -------------------------------- | ----------------- | ---------------------------------------------- | ------------- |
+| color--dark                      | CSS color formats | the text color in dark-mode                    |               |
+| container-background-color--dark | CSS color formats | background color of the container in dark-mode |               |
 
 <div class="alert alert-note" role="alert">
   <p>Note</p>

--- a/packages/mjml-text/src/index.js
+++ b/packages/mjml-text/src/index.js
@@ -174,6 +174,7 @@ export default class MjText extends BodyComponent {
     'color--dark': 'color',
     'container-background-color': 'color',
     'container-background-color--dark': 'color',
+    'container-border-radius': 'string',
     'font-family': 'string',
     'font-size': 'unit(px,rem)',
     'font-size--responsive': 'unit(px,rem)',

--- a/packages/mjml/test/social-align.test.js
+++ b/packages/mjml/test/social-align.test.js
@@ -28,7 +28,7 @@ describe('mj-social-element align', function () {
     // align values should be correct
     chai
       .expect(
-        $('.my-social-element > td:first-child')
+        $('.my-social-element > td > table td:first-child')
           .map(function getAttr() {
             const style = $(this).attr('style')
             return extractStyle(style, 'text-align')

--- a/packages/mjml/test/social-dark-color-background-color.test.js
+++ b/packages/mjml/test/social-dark-color-background-color.test.js
@@ -115,9 +115,9 @@ describe('mj-social / mj-social-element dark color/background', function () {
     chai.expect(styles).to.include('.mj-dark-1 { background-color: #111111 !important; }')
     chai.expect(styles).to.include('.mj-dark-2 { background-color: #222222 !important; }')
     chai.expect($('td.mj-dark-1').get().length).to.be.at.least(1)
-    chai.expect($('table.mj-dark-2').get().length).to.be.at.least(1)
+    chai.expect($('td.mj-dark-2').get().length).to.be.at.least(1)
     chai.expect($('table.mj-dark-1').get().length).to.equal(0)
-    chai.expect($('td.mj-dark-2').get().length).to.equal(0)
+    chai.expect($('table.mj-dark-2').get().length).to.equal(0)
   })
 
   it('should not emit [data-ogsb] dark rules by default', async function () {

--- a/packages/mjml/test/social-icon-height.test.js
+++ b/packages/mjml/test/social-icon-height.test.js
@@ -27,7 +27,7 @@ describe('mj-social icon-height', function () {
     // height values should be correct
     chai
       .expect(
-        $('.my-social-element > td > table > tbody > tr > td')
+        $('.my-social-element > td > table > tbody > tr > td:first-child')
           .map(function getAttr() {
             const start = $(this).attr('style').indexOf('height:') + 7
             const end = $(this).attr('style').indexOf(';', start)
@@ -40,7 +40,7 @@ describe('mj-social icon-height', function () {
 
     chai
       .expect(
-        $('.my-social-element > td > table > tbody > tr > td img')
+        $('.my-social-element > td > table > tbody > tr > td:first-child img')
           .map(function getAttr() {
             return $(this).attr('height')
           })

--- a/packages/mjml/test/social-responsive-mode.test.js
+++ b/packages/mjml/test/social-responsive-mode.test.js
@@ -1,0 +1,89 @@
+const chai = require('chai')
+const { load } = require('cheerio')
+const mjml = require('../lib')
+
+function allHeadStyles(html) {
+  const $ = load(html)
+  return $('head style')
+    .map(function () {
+      return $(this).text()
+    })
+    .get()
+    .join('\n')
+}
+
+function wrapSocial(attrs, elements) {
+  return `
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-social mode="horizontal" ${attrs}>
+          ${elements}
+        </mj-social>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`
+}
+
+const ELEMENTS = `
+  <mj-social-element name="facebook" href="https://mjml.io/">Facebook</mj-social-element>
+  <mj-social-element name="twitter" href="https://mjml.io/">Twitter</mj-social-element>
+`
+
+describe('mj-social responsive-mode="stack"', function () {
+  it('adds mj-social-stack class to each inline-table wrapper', async function () {
+    const { html } = await mjml(wrapSocial('responsive-mode="stack"', ELEMENTS))
+    const $ = load(html)
+    chai.expect($('table.mj-social-stack').length).to.equal(2)
+  })
+
+  it('does not add mj-social-stack class when responsive-mode is not set', async function () {
+    const { html } = await mjml(wrapSocial('', ELEMENTS))
+    chai.expect(html).to.not.include('mj-social-stack')
+  })
+
+  it('emits the stack @media CSS block in the head', async function () {
+    const { html } = await mjml(wrapSocial('responsive-mode="stack"', ELEMENTS))
+    const styles = allHeadStyles(html)
+    chai.expect(styles).to.include('.mj-social-stack')
+    chai.expect(styles).to.include('display: table !important')
+    chai.expect(styles).to.include('float: none !important')
+    chai.expect(styles).to.include('@media only screen and (max-width:479px)')
+  })
+
+  it('does not emit the stack style block when responsive-mode is not set', async function () {
+    const { html } = await mjml(wrapSocial('', ELEMENTS))
+    const styles = allHeadStyles(html)
+    chai.expect(styles).to.not.include('.mj-social-stack')
+  })
+
+  it('emits the stack style block only once when multiple stack social components are present', async function () {
+    const input = `
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-social mode="horizontal" responsive-mode="stack">
+          ${ELEMENTS}
+        </mj-social>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-social mode="horizontal" responsive-mode="stack">
+          ${ELEMENTS}
+        </mj-social>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`
+    const { html } = await mjml(input)
+    const styles = allHeadStyles(html)
+    const occurrences = (styles.match(/\.mj-social-stack\s*\{/g) || []).length
+    chai.expect(occurrences).to.equal(1)
+  })
+})


### PR DESCRIPTION
## What's changed

### Feature
- Added `container-border-radius` attribute to 10 components
- Added `container-background-color` attribute to mj-navbar
- Updated `mj-social` padding attributes to be more logical. Removing `inner-padding`, `text-padding` and replaced with `gutter` and `text-spacing`, plus removed all padding override options for `mj-social-element`
- Added `responsive-mode` to `mj-social` to stack elements on smaller screens

### Documentation
- Updated documentation

### Testing
- Added regression testing