### PR TITLE
chore(deps): bump htmlnano to 3.5.0

### DIFF
--- a/.github/workflows/mjml-workflow.yml
+++ b/.github/workflows/mjml-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Build browser bundle + smoke test
         run: |
           yarn install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install
       - run: yarn build

--- a/packages/mjml-core/package.json
+++ b/packages/mjml-core/package.json
@@ -27,7 +27,7 @@
     "cssnano": "^7.1.9",
     "cssnano-preset-lite": "^4.0.6",
     "detect-node": "^2.0.4",
-    "htmlnano": "3.3.1",
+    "htmlnano": "3.5.0",
     "js-beautify": "^2.0.3",
     "juice": "^11.1.1",
     "lodash": "^4.17.21",

--- a/packages/mjml-core/src/index.js
+++ b/packages/mjml-core/src/index.js
@@ -904,6 +904,12 @@ export default async function mjml2html(mjml, options = {}) {
       removeEmptyAttributes: true,
       minifyJs: false,
       removeComments: keepComments ? false : 'safe',
+      // htmlnano's safe preset decodes character references to raw UTF-8
+      // (`&nbsp;` -> U+00A0, `&#8202;` -> U+200A). Email output travels through
+      // ESP template engines and transports that re-encode payloads, where raw
+      // bytes turn into mojibake, so keep the references escaped. Callers can
+      // opt in through `minifyOptions`.
+      minifyCharacterReferences: false,
       ...minifyOptionsRest,
     }
 

--- a/packages/mjml/test/minify-character-references.test.js
+++ b/packages/mjml/test/minify-character-references.test.js
@@ -1,0 +1,68 @@
+const chai = require('chai')
+const mjml = require('../lib')
+
+const NBSP = ' '
+const HAIR_SPACE = ' '
+
+describe('character references when minifying', function () {
+  this.timeout(10000)
+
+  // ---------------------------------------------------------------------------
+  // htmlnano's safe preset decodes character references to raw UTF-8 since 3.4.0.
+  // mjml keeps them escaped so minified output survives ESP template engines and
+  // transports that re-encode the payload.
+  // ---------------------------------------------------------------------------
+
+  it('keeps the &#8202; emitted by mj-spacer escaped', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-spacer height="50px" />
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+    const { html } = await mjml(input, { minify: true })
+    chai.expect(html).to.include('&#8202;')
+    chai.expect(html).to.not.include(HAIR_SPACE)
+  })
+
+  it('keeps character references in user content escaped', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-text>Caf&eacute;&nbsp;&amp; co. &mdash; &copy;2026</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+    const { html } = await mjml(input, { minify: true })
+    chai.expect(html).to.include('Caf&eacute;&nbsp;&amp; co. &mdash; &copy;2026')
+  })
+
+  it('lets callers opt in through minifyOptions', async function () {
+    const input = `
+      <mjml>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-text>a&nbsp;b</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    `
+    const { html } = await mjml(input, {
+      minify: true,
+      minifyOptions: { minifyCharacterReferences: true },
+    })
+    chai.expect(html).to.include(`a${NBSP}b`)
+    chai.expect(html).to.not.include('a&nbsp;b')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,10 +3637,15 @@ commander@^12.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
-commander@^14.0.0, commander@^14.0.3:
+commander@^14.0.3:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
   integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
+
+commander@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-15.0.0.tgz#96f3961f12adac1799ef3fbd8bc61d40572d1b11"
+  integrity sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -3837,6 +3842,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cosmiconfig@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-10.0.1.tgz#af7d6e328a18a7b04fc20c8064bf3c74ae452549"
+  integrity sha512-/zvGoYn0y27QTBmK+0B+oPdEPC4fKGUmJsMTQbDjqph00TrkqfVFW/M+C6ya54sYCgHC6QCwK/mI6djt8cEGHQ==
+  dependencies:
+    env-paths "^2.2.1"
+    js-yaml "^5.4.1"
+
 cosmiconfig@^5.1.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz"
@@ -3846,16 +3859,6 @@ cosmiconfig@^5.1.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-cosmiconfig@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.2.tgz#9e5615163becf6a82211fb33d2f68947c25d0c5e"
-  integrity sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==
-  dependencies:
-    env-paths "^2.2.1"
-    import-fresh "^3.3.0"
-    js-yaml "^4.1.0"
-    parse-json "^5.2.0"
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -5041,6 +5044,11 @@ fast-uri@3.1.2, fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz"
@@ -5806,15 +5814,17 @@ html-minifier-terser@^7.2.0:
     relateurl "^0.2.7"
     terser "^5.15.1"
 
-htmlnano@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-3.3.1.tgz#bcdc0e1508a99a387d0692900208b14f0ae629ab"
-  integrity sha512-UXOwkDA1WUFSamPXpCzJz131mqbuaenm4Agra3VTpP6lpbuCytILqXEAG5kwzkeksDnFQ+JG3EhVVqpBPsh51w==
+htmlnano@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-3.5.0.tgz#69997c63c80d2e20e68e1ebd9632115374621a95"
+  integrity sha512-2lmhdJIGOxasQALy4ntENIaiJbnc0DsqJcANpx1930Hx0HLzituoE9pnmryFrT6UI7XJzcWk12Gd+C0q9ZtY0A==
   dependencies:
     "@types/relateurl" "^0.2.33"
-    commander "^14.0.0"
-    cosmiconfig "^9.0.0"
+    commander "^15.0.0"
+    cosmiconfig "^10.0.0"
+    entities "^4.5.0"
     posthtml "^0.16.5"
+    tinyglobby "^0.2.17"
 
 htmlparser2@^10.1.0:
   version "10.1.0"
@@ -5935,7 +5945,7 @@ import-fresh@^3.0.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-fresh@^3.2.1, import-fresh@^3.3.0:
+import-fresh@^3.2.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz"
   integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
@@ -6462,6 +6472,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.4.1.tgz#4629d91d4b4551f300435f0e4127899710f816fb"
+  integrity sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -7897,7 +7914,7 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-json@^5.0.0, parse-json@^5.2.0:
+parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -8071,7 +8088,7 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^4.0.4:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
@@ -9828,6 +9845,14 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Bumps `htmlnano` in `mjml-core` from 3.3.1 to 3.5.0 ([changelog](https://github.com/posthtml/htmlnano/blob/master/CHANGELOG.md)).

## Why

htmlnano 3.3.1 declares a peer dependency of `cssnano ^8.0.0`, while `mjml-core` depends on `cssnano ^7.1.9`. `npm --strict-peer-deps` fails outright with `ERESOLVE`, and pnpm reports `✕ unmet peer cssnano@^8.0.0: found 7.1.9` — a warning by default, an error under `strict-peer-dependencies` — so downstream projects end up carrying a patch to install mjml. htmlnano 3.3.2 widened the range to `^7 || ^8` ([#434](https://github.com/posthtml/htmlnano/issues/434)); 3.5.0 accepts `^7 || ^8 || ^9` and is current. Yarn classic doesn't surface this because it honours `peerDependenciesMeta.optional`, so the mismatch is invisible in this repo's own install.

## This drops Node 20 from CI

htmlnano 3.4.0 moved to `commander` 15 (`engines: node >=22.12.0`) and 3.5.0 to `cosmiconfig` 10 (`engines: node ^22.18 || >=24`). Yarn classic treats an engine mismatch as fatal, so on the current matrix's Node 20 leg:

```
error commander@15.0.0: The engine "node" is incompatible with this module. Expected version ">=22.12.0". Got "20.20.2"
error Found incompatible module.
```

Node 20 reached [end of life on 2026-04-30](https://github.com/nodejs/Release), so this PR drops `20.x` from the test matrix and moves the `browser-smoke` and `npm-publish` jobs to `22.x`. **The publish workflow change is included because it also runs `yarn install`** — without it, releases would break on the next dispatch. Worth a careful look, since it's the release path.

Two things worth knowing:

- The effective floor is **Node 22.18**, set by `cosmiconfig`, not the 22.12 in the error above. CI's `22.x` resolves well past that.
- This is an *install-time* constraint, not a runtime one. I confirmed htmlnano 3.5.0 executes fine on Node 20.20.2 — `commander` is only reachable from htmlnano's CLI bin, never from the library entry point. So npm/pnpm users on Node 20 would keep working; only yarn-classic installs hard-fail.

### Why the matrix stops at 24

Node 26 becomes LTS on 2026-10-28, so it's a natural next addition — but the test suite can't run on it yet, and that's unrelated to this PR. `mocha@10` resolves `yargs@16.2.0`, whose extensionless `node_modules/yargs/yargs` entry Node 26 loads as ESM:

```
ReferenceError: require is not defined in ES module scope, you can use import instead
    at .../node_modules/yargs/yargs:3:69
```

I confirmed this reproduces on unmodified `master` (htmlnano 3.3.1) under Node 26.8.1, so it's a pre-existing tooling issue rather than a regression here. Adding `26.x` would just paint CI red. `install`, `build`, `lint` and `build-browser` all pass on Node 26 — only `test` fails. Worth resolving separately before 26 promotes; happy to open a separate issue or PR for it.

If dropping Node 20 isn't something you want to do in a dependency bump, **3.3.2 is the last version that installs on Node 20** and still fixes the cssnano peer range. Happy to retarget this PR to 3.3.2 instead — just say the word.

## Output behaviour

Since 3.4.0 the `safe` preset enables `minifyCharacterReferences`, which decodes character references to raw UTF-8. mjml emits `&nbsp;` (`mj-divider`) and `&#8202;` (`mj-spacer`), and mjml's own output carries the XHTML namespace on `<html>`. Straight bump, before → after:

```
-  ...line-height:50px">&#8202;</div>            +  ...line-height:50px">⟨U+200A⟩</div>
-  Hello&nbsp;world &mdash; caf&eacute; &amp; co. &lt;tag&gt; &copy;2026
+  Hello⟨U+00A0⟩world ⟨U+2014⟩ caf⟨U+00E9⟩ & co. &lt;tag> ⟨U+00A9⟩2026
```

Raw `U+00A0`/`U+200A` bytes and a bare `&` are exactly what ESP template engines and re-encoding transports mangle, so I've pinned `minifyCharacterReferences: false` in `htmlnanoOptions`. It sits before the `...minifyOptionsRest` spread, so callers can still opt in via `minifyOptions`. Three regression tests cover it; two of them fail without the pin.

With that pin, the only remaining output change across the templates I rendered is one byte per document, from 3.4.0's `minifyAttributes` handling of the viewport meta:

```
- <meta name="viewport" content="width=device-width, initial-scale=1">
+ <meta name="viewport" content="width=device-width,initial-scale=1">
```

Semantically identical and universally parsed, so I left it. `dir="ltr"` stripping (new in 3.5.0) doesn't affect default output — mjml emits `dir="auto"`.

## Verification

Full CI sequence (`yarn install --frozen-lockfile && yarn build && yarn lint && yarn test && yarn build-browser`) green on **Node 22.22.3 and 24.20.0**: 134 tests passing, lint clean (5 pre-existing `no-console` warnings), browser smoke test passes. Node 20 was not tested — it cannot install, which is the point of the matrix change.

Output comparison was done by rendering five templates (divider, spacer, entity-heavy text, comments, and a combined one) with `minify: true` on 3.3.1 and on this branch, both under Node 22, and diffing the bytes. I also rendered the 3.3.1 baseline under Node 20 and 22 to confirm the Node version itself doesn't affect output.

Lockfile changes are scoped to htmlnano and its transitives: `commander` 15, `cosmiconfig` 10, `tinyglobby`, `fdir`, `js-yaml` 5, `picomatch` 4.
